### PR TITLE
Allow execution role to be passed into the lambda

### DIFF
--- a/.changeset/green-singers-fetch.md
+++ b/.changeset/green-singers-fetch.md
@@ -1,0 +1,5 @@
+---
+'@wanews/pulumi-lambda': patch
+---
+
+Add ability to pass execution role into lambda

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,8 +6,33 @@ on:
       - master
 
 jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      changes: ${{ steps.version.changes }} # map step output to job output
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          fetch-depth: 0
+          token: ${{ secrets.GIT_PAT }}
+
+      - name: Version command
+        id: version
+        run: echo ::set-output name=changes::$(pnpx changeset version | grep -q 'No unreleased changesets found, exiting.' && echo 'false' || echo 'true')
+
+      - name: Push changes
+        if: steps.version.outputs.changes === 'true'
+        run: |
+          git add -A
+          git commit -m "Version packages"
+          git push --ff-only
+
   build:
     runs-on: ubuntu-latest
+    needs: version
+    if: needs.version.outputs.changes === 'false'
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/libs/pulumi-lambda/src/lib/lambda-function.ts
+++ b/libs/pulumi-lambda/src/lib/lambda-function.ts
@@ -24,6 +24,8 @@ export class LambdaFunction extends pulumi.ComponentResource {
              * Once imported, this param needs to be removed
              **/
             logGroupImport?: string
+
+            skipAttachDenyPolicy?: boolean
         },
         opts?: pulumi.ComponentResourceOptions | undefined,
     ) {
@@ -91,14 +93,15 @@ export class LambdaFunction extends pulumi.ComponentResource {
             { parent: this },
         )
 
-        new aws.iam.RolePolicyAttachment(
-            `${name}-attach-deny`,
-            {
-                role: this.executionRole,
-                policyArn: pulumi.interpolate`arn:aws:iam::${accountId}:policy/deny-log-group-creation`,
-            },
-            { parent: this },
-        )
+        !args.skipAttachDenyPolicy &&
+            new aws.iam.RolePolicyAttachment(
+                `${name}-attach-deny`,
+                {
+                    role: this.executionRole,
+                    policyArn: pulumi.interpolate`arn:aws:iam::${accountId}:policy/deny-log-group-creation`,
+                },
+                { parent: this },
+            )
 
         this.function = new aws.lambda.Function(
             name,

--- a/libs/pulumi-lambda/src/lib/lambda-function.ts
+++ b/libs/pulumi-lambda/src/lib/lambda-function.ts
@@ -11,6 +11,8 @@ export class LambdaFunction extends pulumi.ComponentResource {
         args: {
             lambdaOptions: Omit<aws.lambda.FunctionArgs, 'role'>
 
+            executionRole?: aws.iam.Role
+
             getTags: (
                 name: string,
             ) => {
@@ -53,25 +55,27 @@ export class LambdaFunction extends pulumi.ComponentResource {
         )
 
         const roleName = `${name}-role`
-        this.executionRole = new aws.iam.Role(
-            roleName,
-            {
-                assumeRolePolicy: {
-                    Version: '2012-10-17',
-                    Statement: [
-                        {
-                            Action: 'sts:AssumeRole',
-                            Principal: {
-                                Service: 'lambda.amazonaws.com',
+        this.executionRole =
+            args.executionRole ||
+            new aws.iam.Role(
+                roleName,
+                {
+                    assumeRolePolicy: {
+                        Version: '2012-10-17',
+                        Statement: [
+                            {
+                                Action: 'sts:AssumeRole',
+                                Principal: {
+                                    Service: 'lambda.amazonaws.com',
+                                },
+                                Effect: 'Allow',
                             },
-                            Effect: 'Allow',
-                        },
-                    ],
+                        ],
+                    },
+                    tags: args.getTags(name),
                 },
-                tags: args.getTags(name),
-            },
-            { parent: this },
-        )
+                { parent: this },
+            )
 
         const accountId = pulumi.output(
             aws


### PR DESCRIPTION
This PR makes 2 changes, one around changesets one around the package itself.

The goal of the lambda package is to create each lambda in a way that it has a TAGGED log group, so the logging costs of that lambda can be measured.
This is done by not allowing lambdas permissions to create their own log groups.

## Package change
Serverless mono creates it's own execution role, it is easier to just keep using that then attach the deny policy to it.

## Changesets change
* Tries to version packages, if any packages are versioned commit those changes
* Only run the build if no packages were versioned

This ensures that the git changes are made quickly, then bail out. And the triggered build from that will do the build/release of those packages as a separate run