### PR TITLE
Add optional metric alarms to pulumi-lambda

### DIFF
--- a/.changeset/long-rabbits-happen.md
+++ b/.changeset/long-rabbits-happen.md
@@ -1,0 +1,5 @@
+---
+'@wanews/pulumi-lambda': minor
+---
+
+add optional metric alarms

--- a/libs/pulumi-lambda/README.md
+++ b/libs/pulumi-lambda/README.md
@@ -19,19 +19,45 @@ const lambda = new LambdaFunction(`my-lambda`, {
 })
 ```
 
-To enable monitoring:
+## Monitoring
+
+`RecommendedAlarms` provides an opinionated set of alarms for a lambda function:
 
 ```ts
-import { MetricAlarms } from '@wanews/pulumi-lambda'
+import { RecommendedAlarms } from '@wanews/pulumi-lambda'
 
-new MetricAlarms(name, {
-  snsTopicArn: 'arn:aws:sns:<region>:<account>:<topic>>',
+new RecommendedAlarms(name, {
+  snsTopicArn: 'arn:aws:sns:<region>:<account>:<topic>',
+  lambdaFunctionName: lambda.function.name,
   thresholds: {
     timeoutMs: pulumi
       .output(lambda.function.timeout)
       .apply((timeout) => (timeout ?? 3) * 1000),
   },
+  getTags(name) {
+    return { name }
+  },
+})
+```
+
+You can also create individual alarms, or set up multiple alarms for the same metric:
+
+```ts
+import { AvgDurationAlarm } from '@wanews/pulumi-lambda'
+
+const warn = new AvgDurationAlarm(name, {
+  snsTopicArn: 'arn:aws:sns:<region>:<account>:<topic-warn>',
   lambdaFunctionName: lambda.function.name,
+  avgDurationMs: 3000,
+  getTags(name) {
+    return { name }
+  },
+})
+
+const error = new AvgDurationAlarm(name, {
+  snsTopicArn: 'arn:aws:sns:<region>:<account>:<topic-error>',
+  lambdaFunctionName: lambda.function.name,
+  avgDurationMs: 7000,
   getTags(name) {
     return { name }
   },

--- a/libs/pulumi-lambda/README.md
+++ b/libs/pulumi-lambda/README.md
@@ -32,5 +32,8 @@ new MetricAlarms(name, {
       .apply((timeout) => (timeout ?? 3) * 1000),
   },
   lambdaFunctionName: lambda.function.name,
+  getTags(name) {
+    return { name }
+  },
 })
 ```

--- a/libs/pulumi-lambda/README.md
+++ b/libs/pulumi-lambda/README.md
@@ -7,9 +7,38 @@ This ensures logging costs are tagged appropriately.
 ## Usage
 
 ```ts
+import { LambdaFunction } from '@wanews/pulumi-lambda'
+
 new LambdaFunction(`my-lambda`, {
   lambdaOptions: {
     // See https://www.pulumi.com/docs/reference/pkg/aws/lambda/function/#inputs
+  },
+  getTags(name) {
+    return { name }
+  },
+})
+```
+
+To enable monitoring:
+
+```ts
+import { LambdaFunction } from '@wanews/pulumi-lambda'
+
+new LambdaFunction(`my-lambda`, {
+  lambdaOptions: {
+    // See https://www.pulumi.com/docs/reference/pkg/aws/lambda/function/#inputs
+  },
+  monitoring: {
+    enabled: true,
+    snsTopicArn: 'arn:aws:sns:<region>:<account>:<topic>',
+    // optional, but recommended: override thresholds
+    thresholds: {
+      avgDurationMs: 3000, // 3 seconds
+      maxDurationMs: 15000, // 15 seconds
+      errorRatePercent: 2, // 2 percent
+      throttles: 1,
+      concurrents: 450,
+    },
   },
   getTags(name) {
     return { name }

--- a/libs/pulumi-lambda/README.md
+++ b/libs/pulumi-lambda/README.md
@@ -9,7 +9,7 @@ This ensures logging costs are tagged appropriately.
 ```ts
 import { LambdaFunction } from '@wanews/pulumi-lambda'
 
-new LambdaFunction(`my-lambda`, {
+const lambda = new LambdaFunction(`my-lambda`, {
   lambdaOptions: {
     // See https://www.pulumi.com/docs/reference/pkg/aws/lambda/function/#inputs
   },
@@ -22,26 +22,15 @@ new LambdaFunction(`my-lambda`, {
 To enable monitoring:
 
 ```ts
-import { LambdaFunction } from '@wanews/pulumi-lambda'
+import { MetricAlarms } from '@wanews/pulumi-lambda'
 
-new LambdaFunction(`my-lambda`, {
-  lambdaOptions: {
-    // See https://www.pulumi.com/docs/reference/pkg/aws/lambda/function/#inputs
+new MetricAlarms(name, {
+  snsTopicArn: 'arn:aws:sns:<region>:<account>:<topic>>',
+  thresholds: {
+    timeoutMs: pulumi
+      .output(lambda.function.timeout)
+      .apply((timeout) => (timeout ?? 3) * 1000),
   },
-  monitoring: {
-    enabled: true,
-    snsTopicArn: 'arn:aws:sns:<region>:<account>:<topic>',
-    // optional, but recommended: override thresholds
-    thresholds: {
-      avgDurationMs: 3000, // 3 seconds
-      maxDurationMs: 15000, // 15 seconds
-      errorRatePercent: 2, // 2 percent
-      throttles: 1,
-      concurrents: 450,
-    },
-  },
-  getTags(name) {
-    return { name }
-  },
+  lambdaFunctionName: lambda.function.name,
 })
 ```

--- a/libs/pulumi-lambda/src/index.ts
+++ b/libs/pulumi-lambda/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/lambda-function'
+export * from './lib/metric-alarms'

--- a/libs/pulumi-lambda/src/lib/lambda-function.ts
+++ b/libs/pulumi-lambda/src/lib/lambda-function.ts
@@ -1,6 +1,5 @@
 import * as pulumi from '@pulumi/pulumi'
 import * as aws from '@pulumi/aws'
-import { Thresholds, MetricAlarms } from './metric-alarms'
 
 export class LambdaFunction extends pulumi.ComponentResource {
     readonly function: aws.lambda.Function

--- a/libs/pulumi-lambda/src/lib/lambda-function.ts
+++ b/libs/pulumi-lambda/src/lib/lambda-function.ts
@@ -2,13 +2,6 @@ import * as pulumi from '@pulumi/pulumi'
 import * as aws from '@pulumi/aws'
 import { Thresholds, MetricAlarms } from './metric-alarms'
 
-/**
- * - removes sumo logging
- * - adds a default execution role (but still allows it to be overridden)
- * - updates default runtime node12 --> node14
- * - removes all aws.lambda.Permission (allowInvocationBy)
- */
-
 export class LambdaFunction extends pulumi.ComponentResource {
     readonly function: aws.lambda.Function
     readonly executionRole: aws.iam.Role

--- a/libs/pulumi-lambda/src/lib/lambda-function.ts
+++ b/libs/pulumi-lambda/src/lib/lambda-function.ts
@@ -26,23 +26,6 @@ export class LambdaFunction extends pulumi.ComponentResource {
              * Once imported, this param needs to be removed
              **/
             logGroupImport?: string
-
-            /**
-             * If enabled, metric alarms will be created, and alerts will be raised to the
-             * SNS topic provided. Optional thresholds can be set.
-             * Default: disabled
-             */
-            monitoring?:
-                | {
-                      enabled: true
-                      thresholds?: Omit<Thresholds, 'timeoutMs'>
-                      snsTopicArn: pulumi.Input<string>
-                  }
-                | {
-                      enabled: false
-                      thresholds?: undefined
-                      snsTopicArn?: undefined
-                  }
         },
         opts?: pulumi.ComponentResourceOptions | undefined,
     ) {
@@ -122,18 +105,5 @@ export class LambdaFunction extends pulumi.ComponentResource {
                 dependsOn: [this.logGroup],
             },
         )
-
-        if (args.monitoring?.enabled) {
-            new MetricAlarms(name, {
-                snsTopicArn: args.monitoring.snsTopicArn,
-                thresholds: {
-                    ...(args.monitoring?.thresholds ?? {}),
-                    timeoutMs: pulumi
-                        .output(this.function.timeout)
-                        .apply((timeout) => (timeout ?? 3) * 1000),
-                },
-                lambdaFunctionName: this.function.name,
-            })
-        }
     }
 }

--- a/libs/pulumi-lambda/src/lib/metric-alarms.ts
+++ b/libs/pulumi-lambda/src/lib/metric-alarms.ts
@@ -1,54 +1,16 @@
 import * as pulumi from '@pulumi/pulumi'
 import * as aws from '@pulumi/aws'
 
-export const defaultThresholds = {
-    avgDurationMs: 3000,
-    maxDurationMs: 15000,
-    errorRatePercent: 2,
-    throttles: 1,
-    concurrents: 450,
-}
-
-export interface Thresholds {
-    /**
-     * Alert if the average duration is greater than this
-     * Default: 3000ms (3 seconds)
-     */
-    avgDurationMs?: pulumi.Input<number>
-    /**
-     * Alert if the max duration is greater than this
-     * Default: not used (undefined)
-     */
-    maxDurationMs?: pulumi.Input<number>
-    /**
-     * Alert if the max duration is greater than this
-     * Default: not used (undefined)
-     */
-    timeoutMs?: pulumi.Input<number>
-    /**
-     * Alert if the error rate exceeds this
-     * (default: 2 percent)
-     */
-    errorRatePercent?: pulumi.Input<number>
-    /**
-     * Throttles are bad mkay
-     * default: 1 throttle in the last 5 minutes
-     */
-    throttles?: pulumi.Input<number>
-    /**
-     * Alert if concurrent executions exceeds this
-     * This has a cost implication, but it can also
-     * cause throttles if it rises too fast
-     * default: more than 450 concurrents at any
-     * time in the past 5 minutes
-     */
-    concurrents?: pulumi.Input<number>
-}
-
 /**
- * Provides common metric alarms for a lambda function
+ * Provides an opinionated set of recommended alarms for a lambda function.
+ *
+ * Raise alarms for the following:
+ *  - function has timed out (calculated using max duration)
+ *  - function error rate exceeded (default: 2%)
+ *  - function has too many concurrent executions (default: 450 concurrents)
+ *  - function has been throttled (default: one or more throttles have occurred)
  */
-export class MetricAlarms extends pulumi.ComponentResource {
+export class RecommendedAlarms extends pulumi.ComponentResource {
     constructor(
         name: string,
         args: {
@@ -61,9 +23,14 @@ export class MetricAlarms extends pulumi.ComponentResource {
              */
             lambdaFunctionName: pulumi.Input<string>
             /**
-             * Set custom thresholds for the alarms
+             * Set thresholds for the alarms
              */
-            thresholds?: Thresholds
+            thresholds: {
+                timeoutMs: pulumi.Input<number>
+                errorRatePercent?: pulumi.Input<number>
+                concurrents?: pulumi.Input<number>
+                throttles?: pulumi.Input<number>
+            }
             /**
              * a callback function that returns tags for
              * each resource
@@ -76,11 +43,75 @@ export class MetricAlarms extends pulumi.ComponentResource {
         },
         opts?: pulumi.ComponentResourceOptions,
     ) {
-        super('wanews:lambda/MetricAlarms', name, {}, opts)
+        super('wanews:lambda/RecommendedAlarms', name, {}, opts)
 
-        const errorRateName = `${name}-err-rate`
+        new FunctionTimeoutAlarm(name, {
+            snsTopicArn: args.snsTopicArn,
+            lambdaFunctionName: args.lambdaFunctionName,
+            getTags: args.getTags,
+            timeoutMs: args.thresholds.timeoutMs,
+        })
+
+        new ErrorRateAlarm(name, {
+            snsTopicArn: args.snsTopicArn,
+            lambdaFunctionName: args.lambdaFunctionName,
+            getTags: args.getTags,
+            errorRatePercent: args.thresholds.errorRatePercent,
+        })
+
+        new ConcurrentExecutionsAlarm(name, {
+            snsTopicArn: args.snsTopicArn,
+            lambdaFunctionName: args.lambdaFunctionName,
+            getTags: args.getTags,
+            concurrents: args.thresholds.concurrents,
+        })
+
+        new FunctionThrottledAlarm(name, {
+            snsTopicArn: args.snsTopicArn,
+            lambdaFunctionName: args.lambdaFunctionName,
+            getTags: args.getTags,
+            throttles: args.thresholds.throttles,
+        })
+    }
+}
+
+/** raise an alarm if the error rate exceeds errorRatePercent */
+export class ErrorRateAlarm extends pulumi.ComponentResource {
+    constructor(
+        name: string,
+        args: {
+            /**
+             * Alerts will be sent to this SNS topic
+             */
+            snsTopicArn: pulumi.Input<string>
+            /**
+             * The name of the function to monitor
+             */
+            lambdaFunctionName: pulumi.Input<string>
+            /**
+             * Alert if the error rate exceeds this
+             * (default: 2 percent)
+             */
+            errorRatePercent?: pulumi.Input<number>
+            /**
+             * a callback function that returns tags for
+             * each resource
+             */
+            getTags: (
+                name: string,
+            ) => {
+                [key: string]: pulumi.Input<string>
+            }
+        },
+        opts?: pulumi.ComponentResourceOptions,
+    ) {
+        super('wanews:lambda/ErrorRateAlarm', name, {}, opts)
+
+        const threshold = args.errorRatePercent ?? 2
+        const resourceName = `${name}-err-rate`
+
         new aws.cloudwatch.MetricAlarm(
-            errorRateName,
+            resourceName,
             {
                 metricQueries: [
                     {
@@ -121,43 +152,71 @@ export class MetricAlarms extends pulumi.ComponentResource {
                 evaluationPeriods: 2,
                 datapointsToAlarm: 2,
                 comparisonOperator: 'GreaterThanOrEqualToThreshold',
-                threshold:
-                    args.thresholds?.errorRatePercent ??
-                    defaultThresholds.errorRatePercent,
-                alarmDescription: pulumi.interpolate`threshold: error rate >= ${
-                    args.thresholds?.errorRatePercent ??
-                    defaultThresholds.errorRatePercent
-                }%: ${args.lambdaFunctionName}`,
+                threshold,
+                alarmDescription: pulumi.interpolate`threshold: error rate >= ${threshold}%: ${args.lambdaFunctionName}`,
                 alarmActions: [args.snsTopicArn],
                 okActions: [args.snsTopicArn],
                 insufficientDataActions: [args.snsTopicArn],
                 treatMissingData: 'notBreaching',
-                tags: args.getTags(errorRateName),
+                tags: args.getTags(resourceName),
             },
             {
                 parent: this,
                 deleteBeforeReplace: true,
             },
         )
+    }
+}
 
-        const avgDurationName = `${name}-duration-avg`
+/** raise an alarm if a function times out */
+export class FunctionTimeoutAlarm extends pulumi.ComponentResource {
+    constructor(
+        name: string,
+        args: {
+            /**
+             * Alerts will be sent to this SNS topic
+             */
+            snsTopicArn: pulumi.Input<string>
+            /**
+             * The name of the function to monitor
+             */
+            lambdaFunctionName: pulumi.Input<string>
+            /**
+             * Alert if the max duration is greater than this
+             * Default: not used (undefined)
+             */
+            timeoutMs: pulumi.Input<number>
+            /**
+             * a callback function that returns tags for
+             * each resource
+             */
+            getTags: (
+                name: string,
+            ) => {
+                [key: string]: pulumi.Input<string>
+            }
+        },
+        opts?: pulumi.ComponentResourceOptions,
+    ) {
+        super('wanews:lambda/FunctionTimeoutAlarm', name, {}, opts)
+
+        const threshold = pulumi
+            .output(args.timeoutMs)
+            .apply((timeout) => timeout - 1)
+        const resourceName = `${name}-timeout`
+
         new aws.cloudwatch.MetricAlarm(
-            avgDurationName,
+            resourceName,
             {
                 namespace: 'AWS/Lambda',
                 metricName: 'Duration',
-                statistic: 'Average',
+                statistic: 'Maximum',
                 period: 60,
                 evaluationPeriods: 2,
                 datapointsToAlarm: 2,
                 comparisonOperator: 'GreaterThanOrEqualToThreshold',
-                threshold:
-                    args.thresholds?.avgDurationMs ??
-                    defaultThresholds.avgDurationMs,
-                alarmDescription: pulumi.interpolate`threshold: avg duration >= ${
-                    args.thresholds?.avgDurationMs ??
-                    defaultThresholds.avgDurationMs
-                }: ${args.lambdaFunctionName}`,
+                threshold,
+                alarmDescription: pulumi.interpolate`timeout: max duration >= ${threshold}: ${args.lambdaFunctionName}`,
                 dimensions: {
                     FunctionName: args.lambdaFunctionName,
                     Resource: args.lambdaFunctionName,
@@ -166,116 +225,56 @@ export class MetricAlarms extends pulumi.ComponentResource {
                 okActions: [args.snsTopicArn],
                 insufficientDataActions: [args.snsTopicArn],
                 treatMissingData: 'missing',
-                tags: args.getTags(avgDurationName),
+                tags: args.getTags(resourceName),
             },
             {
                 parent: this,
                 deleteBeforeReplace: true,
             },
         )
+    }
+}
 
-        if (args.thresholds?.maxDurationMs) {
-            const maxDurationName = `${name}-duration-max`
-            new aws.cloudwatch.MetricAlarm(
-                maxDurationName,
-                {
-                    namespace: 'AWS/Lambda',
-                    metricName: 'Duration',
-                    statistic: 'Maximum',
-                    period: 60,
-                    evaluationPeriods: 2,
-                    datapointsToAlarm: 2,
-                    comparisonOperator: 'GreaterThanOrEqualToThreshold',
-                    threshold:
-                        args.thresholds?.maxDurationMs ??
-                        defaultThresholds.maxDurationMs,
-                    alarmDescription: pulumi.interpolate`threshold: max duration >= ${
-                        args.thresholds?.maxDurationMs ??
-                        defaultThresholds.maxDurationMs
-                    }: ${args.lambdaFunctionName}`,
-                    dimensions: {
-                        FunctionName: args.lambdaFunctionName,
-                        Resource: args.lambdaFunctionName,
-                    },
-                    alarmActions: [args.snsTopicArn],
-                    okActions: [args.snsTopicArn],
-                    insufficientDataActions: [args.snsTopicArn],
-                    treatMissingData: 'missing',
-                    tags: args.getTags(maxDurationName),
-                },
-                {
-                    parent: this,
-                    deleteBeforeReplace: true,
-                },
-            )
-        }
+/** raise an alarm if concurrent executions is exceeded */
+export class ConcurrentExecutionsAlarm extends pulumi.ComponentResource {
+    constructor(
+        name: string,
+        args: {
+            /**
+             * Alerts will be sent to this SNS topic
+             */
+            snsTopicArn: pulumi.Input<string>
+            /**
+             * The name of the function to monitor
+             */
+            lambdaFunctionName: pulumi.Input<string>
+            /**
+             * Alert if concurrent executions exceeds this
+             * This has a cost implication, but it can also
+             * cause throttles if it rises too fast
+             * default: more than 450 concurrents at any
+             * time in the past 5 minutes
+             */
+            concurrents?: pulumi.Input<number>
+            /**
+             * a callback function that returns tags for
+             * each resource
+             */
+            getTags: (
+                name: string,
+            ) => {
+                [key: string]: pulumi.Input<string>
+            }
+        },
+        opts?: pulumi.ComponentResourceOptions,
+    ) {
+        super('wanews:lambda/ConcurrentExecutionsAlarm', name, {}, opts)
 
-        if (args.thresholds?.timeoutMs) {
-            const timeoutName = `${name}-timeout`
-            new aws.cloudwatch.MetricAlarm(
-                timeoutName,
-                {
-                    namespace: 'AWS/Lambda',
-                    metricName: 'Duration',
-                    statistic: 'Maximum',
-                    period: 60,
-                    evaluationPeriods: 2,
-                    datapointsToAlarm: 2,
-                    comparisonOperator: 'GreaterThanOrEqualToThreshold',
-                    threshold: args.thresholds.timeoutMs,
-                    alarmDescription: pulumi.interpolate`timeout: max duration >= ${args.thresholds.timeoutMs}: ${args.lambdaFunctionName}`,
-                    dimensions: {
-                        FunctionName: args.lambdaFunctionName,
-                        Resource: args.lambdaFunctionName,
-                    },
-                    alarmActions: [args.snsTopicArn],
-                    okActions: [args.snsTopicArn],
-                    insufficientDataActions: [args.snsTopicArn],
-                    treatMissingData: 'missing',
-                    tags: args.getTags(timeoutName),
-                },
-                {
-                    parent: this,
-                    deleteBeforeReplace: true,
-                },
-            )
-        }
+        const threshold = args.concurrents ?? 450
+        const resourceName = `${name}-concurrents`
 
-        const throttlesName = `${name}-throttles`
         new aws.cloudwatch.MetricAlarm(
-            throttlesName,
-            {
-                namespace: 'AWS/Lambda',
-                metricName: 'Throttles',
-                statistic: 'Sum',
-                period: 60,
-                evaluationPeriods: 5,
-                datapointsToAlarm: 1,
-                comparisonOperator: 'GreaterThanOrEqualToThreshold',
-                threshold:
-                    args.thresholds?.throttles ?? defaultThresholds.throttles,
-                alarmDescription: pulumi.interpolate`threshold: throttles >= ${
-                    args.thresholds?.throttles ?? defaultThresholds.throttles
-                }: ${args.lambdaFunctionName}`,
-                dimensions: {
-                    FunctionName: args.lambdaFunctionName,
-                    Resource: args.lambdaFunctionName,
-                },
-                alarmActions: [args.snsTopicArn],
-                okActions: [args.snsTopicArn],
-                insufficientDataActions: [args.snsTopicArn],
-                treatMissingData: 'notBreaching',
-                tags: args.getTags(throttlesName),
-            },
-            {
-                parent: this,
-                deleteBeforeReplace: true,
-            },
-        )
-
-        const concurrentsName = `${name}-concurrents`
-        new aws.cloudwatch.MetricAlarm(
-            concurrentsName,
+            resourceName,
             {
                 namespace: 'AWS/Lambda',
                 metricName: 'ConcurrentExecutions',
@@ -284,13 +283,8 @@ export class MetricAlarms extends pulumi.ComponentResource {
                 evaluationPeriods: 5,
                 datapointsToAlarm: 1,
                 comparisonOperator: 'GreaterThanOrEqualToThreshold',
-                threshold:
-                    args.thresholds?.concurrents ??
-                    defaultThresholds.concurrents,
-                alarmDescription: pulumi.interpolate`threshold: concurrents >= ${
-                    args.thresholds?.concurrents ??
-                    defaultThresholds.concurrents
-                }: ${args.lambdaFunctionName}`,
+                threshold,
+                alarmDescription: pulumi.interpolate`threshold: concurrents >= ${threshold}: ${args.lambdaFunctionName}`,
                 dimensions: {
                     FunctionName: args.lambdaFunctionName,
                     Resource: args.lambdaFunctionName,
@@ -299,7 +293,202 @@ export class MetricAlarms extends pulumi.ComponentResource {
                 okActions: [args.snsTopicArn],
                 insufficientDataActions: [args.snsTopicArn],
                 treatMissingData: 'notBreaching',
-                tags: args.getTags(concurrentsName),
+                tags: args.getTags(resourceName),
+            },
+            {
+                parent: this,
+                deleteBeforeReplace: true,
+            },
+        )
+    }
+}
+
+/** raise an alarm if a function has been throttled */
+export class FunctionThrottledAlarm extends pulumi.ComponentResource {
+    constructor(
+        name: string,
+        args: {
+            /**
+             * Alerts will be sent to this SNS topic
+             */
+            snsTopicArn: pulumi.Input<string>
+            /**
+             * The name of the function to monitor
+             */
+            lambdaFunctionName: pulumi.Input<string>
+            /**
+             * Throttles are bad mkay
+             * default: 1 throttle in the last 5 minutes
+             */
+            throttles?: pulumi.Input<number>
+            /**
+             * a callback function that returns tags for
+             * each resource
+             */
+            getTags: (
+                name: string,
+            ) => {
+                [key: string]: pulumi.Input<string>
+            }
+        },
+        opts?: pulumi.ComponentResourceOptions,
+    ) {
+        super('wanews:lambda/FunctionThrottledAlarm', name, {}, opts)
+
+        const threshold = args.throttles ?? 1
+        const resourceName = `${name}-throttled`
+
+        new aws.cloudwatch.MetricAlarm(
+            resourceName,
+            {
+                namespace: 'AWS/Lambda',
+                metricName: 'Throttles',
+                statistic: 'Sum',
+                period: 60,
+                evaluationPeriods: 5,
+                datapointsToAlarm: 1,
+                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                threshold,
+                alarmDescription: pulumi.interpolate`threshold: throttled >= ${threshold}: ${args.lambdaFunctionName}`,
+                dimensions: {
+                    FunctionName: args.lambdaFunctionName,
+                    Resource: args.lambdaFunctionName,
+                },
+                alarmActions: [args.snsTopicArn],
+                okActions: [args.snsTopicArn],
+                insufficientDataActions: [args.snsTopicArn],
+                treatMissingData: 'notBreaching',
+                tags: args.getTags(resourceName),
+            },
+            {
+                parent: this,
+                deleteBeforeReplace: true,
+            },
+        )
+    }
+}
+
+/** raise an alarm if the maximum duration exceeds maxDurationMs */
+export class MaxDurationAlarm extends pulumi.ComponentResource {
+    constructor(
+        name: string,
+        args: {
+            /**
+             * Alerts will be sent to this SNS topic
+             */
+            snsTopicArn: pulumi.Input<string>
+            /**
+             * The name of the function to monitor
+             */
+            lambdaFunctionName: pulumi.Input<string>
+            /**
+             * Alert if the max duration is greater than this
+             * Default: not used (undefined)
+             */
+            maxDurationMs?: pulumi.Input<number>
+            /**
+             * a callback function that returns tags for
+             * each resource
+             */
+            getTags: (
+                name: string,
+            ) => {
+                [key: string]: pulumi.Input<string>
+            }
+        },
+        opts?: pulumi.ComponentResourceOptions,
+    ) {
+        super('wanews:lambda/MaxDurationAlarm', name, {}, opts)
+
+        const threshold = args.maxDurationMs ?? 15000
+        const resourceName = `${name}-duration-max`
+
+        new aws.cloudwatch.MetricAlarm(
+            resourceName,
+            {
+                namespace: 'AWS/Lambda',
+                metricName: 'Duration',
+                statistic: 'Maximum',
+                period: 60,
+                evaluationPeriods: 2,
+                datapointsToAlarm: 2,
+                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                threshold,
+                alarmDescription: pulumi.interpolate`threshold: max duration >= ${threshold}: ${args.lambdaFunctionName}`,
+                dimensions: {
+                    FunctionName: args.lambdaFunctionName,
+                    Resource: args.lambdaFunctionName,
+                },
+                alarmActions: [args.snsTopicArn],
+                okActions: [args.snsTopicArn],
+                insufficientDataActions: [args.snsTopicArn],
+                treatMissingData: 'missing',
+                tags: args.getTags(resourceName),
+            },
+            {
+                parent: this,
+                deleteBeforeReplace: true,
+            },
+        )
+    }
+}
+
+/** raise an alarm if the average duration exceeds avgDurationMs */
+export class AvgDurationAlarm extends pulumi.ComponentResource {
+    constructor(
+        name: string,
+        args: {
+            /**
+             * Alerts will be sent to this SNS topic
+             */
+            snsTopicArn: pulumi.Input<string>
+            /**
+             * The name of the function to monitor
+             */
+            lambdaFunctionName: pulumi.Input<string>
+            /**
+             * Alert if the average duration is greater than this
+             * Default: 3000ms (3 seconds)
+             */
+            avgDurationMs?: pulumi.Input<number>
+            /**
+             * a callback function that returns tags for
+             * each resource
+             */
+            getTags: (
+                name: string,
+            ) => {
+                [key: string]: pulumi.Input<string>
+            }
+        },
+        opts?: pulumi.ComponentResourceOptions,
+    ) {
+        super('wanews:lambda/AvgDurationAlarm', name, {}, opts)
+
+        const threshold = args.avgDurationMs ?? 3000
+        const resourceName = `${name}-duration-avg`
+
+        new aws.cloudwatch.MetricAlarm(
+            resourceName,
+            {
+                namespace: 'AWS/Lambda',
+                metricName: 'Duration',
+                statistic: 'Average',
+                period: 60,
+                evaluationPeriods: 2,
+                datapointsToAlarm: 2,
+                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                threshold,
+                alarmDescription: pulumi.interpolate`threshold: avg duration >= ${threshold}: ${args.lambdaFunctionName}`,
+                dimensions: {
+                    FunctionName: args.lambdaFunctionName,
+                    Resource: args.lambdaFunctionName,
+                },
+                alarmActions: [args.snsTopicArn],
+                okActions: [args.snsTopicArn],
+                insufficientDataActions: [args.snsTopicArn],
+                treatMissingData: 'missing',
+                tags: args.getTags(resourceName),
             },
             {
                 parent: this,

--- a/libs/pulumi-lambda/src/lib/metric-alarms.ts
+++ b/libs/pulumi-lambda/src/lib/metric-alarms.ts
@@ -1,0 +1,292 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as aws from '@pulumi/aws'
+
+export const defaultThresholds = {
+    avgDurationMs: 3000,
+    maxDurationMs: 15000,
+    errorRatePercent: 2,
+    throttles: 1,
+    concurrents: 450,
+}
+
+export interface Thresholds {
+    /**
+     * Alert if the average duration is greater than this
+     * Default: 3000ms (3 seconds)
+     */
+    avgDurationMs?: pulumi.Input<number>
+    /**
+     * Alert if the max duration is greater than this
+     * Default: not used (undefined) if timeoutMs is set
+     */
+    maxDurationMs?: pulumi.Input<number>
+    /**
+     * Alert if the max duration
+     * Default: not used (undefined)
+     */
+    timeoutMs?: pulumi.Input<number>
+    /**
+     * Alert if the error rate exceeds this
+     * (default: 2 percent)
+     */
+    errorRatePercent?: pulumi.Input<number>
+    /**
+     * Throttles are bad mkay
+     * default: 1 throttle in the last 5 minutes
+     */
+    throttles?: pulumi.Input<number>
+    /**
+     * Alert if concurrent executions exceeds this
+     * This has a cost implication, but it can also
+     * cause throttles if it rises too fast
+     * default: more than 450 concurrents at any
+     * time in the past 5 minutes
+     */
+    concurrents?: pulumi.Input<number>
+}
+
+/**
+ * Provides common metric alarms for a lambda function
+ */
+export class MetricAlarms extends pulumi.ComponentResource {
+    constructor(
+        name: string,
+        args: {
+            /**
+             * Alerts will be sent to this SNS topic
+             */
+            snsTopicArn: pulumi.Input<string>
+            /**
+             * The name of the function to monitor
+             */
+            lambdaFunctionName: pulumi.Input<string>
+            /**
+             * Set custom thresholds for the alarms
+             */
+            thresholds?: Thresholds
+        },
+        opts?: pulumi.ComponentResourceOptions,
+    ) {
+        super('wanews:lambda/MetricAlarms', name, {}, opts)
+
+        new aws.cloudwatch.MetricAlarm(
+            `${name}-err-rate`,
+            {
+                metricQueries: [
+                    {
+                        id: 'errorRate',
+                        label: 'Error rate (%)',
+                        expression: '100 * errors / MAX([errors, invocations])',
+                        returnData: true,
+                    },
+                    {
+                        id: 'errors',
+                        label: 'Errors',
+                        metric: {
+                            namespace: 'AWS/Lambda',
+                            metricName: 'Errors',
+                            stat: 'Sum',
+                            dimensions: {
+                                FunctionName: args.lambdaFunctionName,
+                                Resource: args.lambdaFunctionName,
+                            },
+                            period: 60,
+                        },
+                    },
+                    {
+                        id: 'invocations',
+                        label: 'Invocations',
+                        metric: {
+                            namespace: 'AWS/Lambda',
+                            metricName: 'Invocations',
+                            stat: 'Sum',
+                            dimensions: {
+                                FunctionName: args.lambdaFunctionName,
+                                Resource: args.lambdaFunctionName,
+                            },
+                            period: 60,
+                        },
+                    },
+                ],
+                evaluationPeriods: 2,
+                datapointsToAlarm: 2,
+                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                threshold:
+                    args.thresholds?.errorRatePercent ??
+                    defaultThresholds.errorRatePercent,
+                alarmDescription: pulumi.interpolate`threshold: error rate >= ${
+                    args.thresholds?.errorRatePercent ??
+                    defaultThresholds.errorRatePercent
+                }%: ${args.lambdaFunctionName}`,
+                alarmActions: [args.snsTopicArn],
+                okActions: [args.snsTopicArn],
+                insufficientDataActions: [args.snsTopicArn],
+                treatMissingData: 'notBreaching',
+            },
+            {
+                parent: this,
+                deleteBeforeReplace: true,
+            },
+        )
+
+        new aws.cloudwatch.MetricAlarm(
+            `${name}-duration-avg`,
+            {
+                namespace: 'AWS/Lambda',
+                metricName: 'Duration',
+                statistic: 'Average',
+                period: 60,
+                evaluationPeriods: 2,
+                datapointsToAlarm: 2,
+                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                threshold:
+                    args.thresholds?.avgDurationMs ??
+                    defaultThresholds.avgDurationMs,
+                alarmDescription: pulumi.interpolate`threshold: avg duration >= ${
+                    args.thresholds?.avgDurationMs ??
+                    defaultThresholds.avgDurationMs
+                }: ${args.lambdaFunctionName}`,
+                dimensions: {
+                    FunctionName: args.lambdaFunctionName,
+                    Resource: args.lambdaFunctionName,
+                },
+                alarmActions: [args.snsTopicArn],
+                okActions: [args.snsTopicArn],
+                insufficientDataActions: [args.snsTopicArn],
+                treatMissingData: 'missing',
+            },
+            {
+                parent: this,
+                deleteBeforeReplace: true,
+            },
+        )
+
+        if (
+            args.thresholds?.maxDurationMs ??
+            args.thresholds?.timeoutMs === undefined
+        ) {
+            new aws.cloudwatch.MetricAlarm(
+                `${name}-duration-max`,
+                {
+                    namespace: 'AWS/Lambda',
+                    metricName: 'Duration',
+                    statistic: 'Maximum',
+                    period: 60,
+                    evaluationPeriods: 2,
+                    datapointsToAlarm: 2,
+                    comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                    threshold:
+                        args.thresholds?.maxDurationMs ??
+                        defaultThresholds.maxDurationMs,
+                    alarmDescription: pulumi.interpolate`threshold: max duration >= ${
+                        args.thresholds?.maxDurationMs ??
+                        defaultThresholds.maxDurationMs
+                    }: ${args.lambdaFunctionName}`,
+                    dimensions: {
+                        FunctionName: args.lambdaFunctionName,
+                        Resource: args.lambdaFunctionName,
+                    },
+                    alarmActions: [args.snsTopicArn],
+                    okActions: [args.snsTopicArn],
+                    insufficientDataActions: [args.snsTopicArn],
+                    treatMissingData: 'missing',
+                },
+                {
+                    parent: this,
+                    deleteBeforeReplace: true,
+                },
+            )
+        }
+
+        if (args.thresholds?.timeoutMs !== undefined) {
+            new aws.cloudwatch.MetricAlarm(
+                `${name}-timeout`,
+                {
+                    namespace: 'AWS/Lambda',
+                    metricName: 'Duration',
+                    statistic: 'Maximum',
+                    period: 60,
+                    evaluationPeriods: 2,
+                    datapointsToAlarm: 2,
+                    comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                    threshold: args.thresholds.timeoutMs,
+                    alarmDescription: pulumi.interpolate`timeout: max duration >= ${args.thresholds.timeoutMs}: ${args.lambdaFunctionName}`,
+                    dimensions: {
+                        FunctionName: args.lambdaFunctionName,
+                        Resource: args.lambdaFunctionName,
+                    },
+                    alarmActions: [args.snsTopicArn],
+                    okActions: [args.snsTopicArn],
+                    insufficientDataActions: [args.snsTopicArn],
+                    treatMissingData: 'missing',
+                },
+                {
+                    parent: this,
+                    deleteBeforeReplace: true,
+                },
+            )
+        }
+
+        new aws.cloudwatch.MetricAlarm(
+            `${name}-throttles`,
+            {
+                namespace: 'AWS/Lambda',
+                metricName: 'Throttles',
+                statistic: 'Sum',
+                period: 60,
+                evaluationPeriods: 5,
+                datapointsToAlarm: 1,
+                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                threshold:
+                    args.thresholds?.throttles ?? defaultThresholds.throttles,
+                alarmDescription: pulumi.interpolate`threshold: throttles >= ${
+                    args.thresholds?.throttles ?? defaultThresholds.throttles
+                }: ${args.lambdaFunctionName}`,
+                dimensions: {
+                    FunctionName: args.lambdaFunctionName,
+                    Resource: args.lambdaFunctionName,
+                },
+                alarmActions: [args.snsTopicArn],
+                okActions: [args.snsTopicArn],
+                insufficientDataActions: [args.snsTopicArn],
+                treatMissingData: 'notBreaching',
+            },
+            {
+                parent: this,
+                deleteBeforeReplace: true,
+            },
+        )
+
+        new aws.cloudwatch.MetricAlarm(
+            `${name}-concurrents`,
+            {
+                namespace: 'AWS/Lambda',
+                metricName: 'ConcurrentExecutions',
+                statistic: 'Maximum',
+                period: 60,
+                evaluationPeriods: 5,
+                datapointsToAlarm: 1,
+                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                threshold:
+                    args.thresholds?.concurrents ??
+                    defaultThresholds.concurrents,
+                alarmDescription: pulumi.interpolate`threshold: concurrents >= ${
+                    args.thresholds?.concurrents ??
+                    defaultThresholds.concurrents
+                }: ${args.lambdaFunctionName}`,
+                dimensions: {
+                    FunctionName: args.lambdaFunctionName,
+                    Resource: args.lambdaFunctionName,
+                },
+                alarmActions: [args.snsTopicArn],
+                okActions: [args.snsTopicArn],
+                insufficientDataActions: [args.snsTopicArn],
+                treatMissingData: 'notBreaching',
+            },
+            {
+                parent: this,
+                deleteBeforeReplace: true,
+            },
+        )
+    }
+}

--- a/libs/pulumi-lambda/src/lib/metric-alarms.ts
+++ b/libs/pulumi-lambda/src/lib/metric-alarms.ts
@@ -64,13 +64,23 @@ export class MetricAlarms extends pulumi.ComponentResource {
              * Set custom thresholds for the alarms
              */
             thresholds?: Thresholds
+            /**
+             * a callback function that returns tags for
+             * each resource
+             */
+            getTags: (
+                name: string,
+            ) => {
+                [key: string]: pulumi.Input<string>
+            }
         },
         opts?: pulumi.ComponentResourceOptions,
     ) {
         super('wanews:lambda/MetricAlarms', name, {}, opts)
 
+        const errorRateName = `${name}-err-rate`
         new aws.cloudwatch.MetricAlarm(
-            `${name}-err-rate`,
+            errorRateName,
             {
                 metricQueries: [
                     {
@@ -122,6 +132,7 @@ export class MetricAlarms extends pulumi.ComponentResource {
                 okActions: [args.snsTopicArn],
                 insufficientDataActions: [args.snsTopicArn],
                 treatMissingData: 'notBreaching',
+                tags: args.getTags(errorRateName),
             },
             {
                 parent: this,
@@ -129,8 +140,9 @@ export class MetricAlarms extends pulumi.ComponentResource {
             },
         )
 
+        const avgDurationName = `${name}-duration-avg`
         new aws.cloudwatch.MetricAlarm(
-            `${name}-duration-avg`,
+            avgDurationName,
             {
                 namespace: 'AWS/Lambda',
                 metricName: 'Duration',
@@ -154,6 +166,7 @@ export class MetricAlarms extends pulumi.ComponentResource {
                 okActions: [args.snsTopicArn],
                 insufficientDataActions: [args.snsTopicArn],
                 treatMissingData: 'missing',
+                tags: args.getTags(avgDurationName),
             },
             {
                 parent: this,
@@ -162,8 +175,9 @@ export class MetricAlarms extends pulumi.ComponentResource {
         )
 
         if (args.thresholds?.maxDurationMs) {
+            const maxDurationName = `${name}-duration-max`
             new aws.cloudwatch.MetricAlarm(
-                `${name}-duration-max`,
+                maxDurationName,
                 {
                     namespace: 'AWS/Lambda',
                     metricName: 'Duration',
@@ -187,6 +201,7 @@ export class MetricAlarms extends pulumi.ComponentResource {
                     okActions: [args.snsTopicArn],
                     insufficientDataActions: [args.snsTopicArn],
                     treatMissingData: 'missing',
+                    tags: args.getTags(maxDurationName),
                 },
                 {
                     parent: this,
@@ -196,8 +211,9 @@ export class MetricAlarms extends pulumi.ComponentResource {
         }
 
         if (args.thresholds?.timeoutMs) {
+            const timeoutName = `${name}-timeout`
             new aws.cloudwatch.MetricAlarm(
-                `${name}-timeout`,
+                timeoutName,
                 {
                     namespace: 'AWS/Lambda',
                     metricName: 'Duration',
@@ -216,6 +232,7 @@ export class MetricAlarms extends pulumi.ComponentResource {
                     okActions: [args.snsTopicArn],
                     insufficientDataActions: [args.snsTopicArn],
                     treatMissingData: 'missing',
+                    tags: args.getTags(timeoutName),
                 },
                 {
                     parent: this,
@@ -224,8 +241,9 @@ export class MetricAlarms extends pulumi.ComponentResource {
             )
         }
 
+        const throttlesName = `${name}-throttles`
         new aws.cloudwatch.MetricAlarm(
-            `${name}-throttles`,
+            throttlesName,
             {
                 namespace: 'AWS/Lambda',
                 metricName: 'Throttles',
@@ -247,6 +265,7 @@ export class MetricAlarms extends pulumi.ComponentResource {
                 okActions: [args.snsTopicArn],
                 insufficientDataActions: [args.snsTopicArn],
                 treatMissingData: 'notBreaching',
+                tags: args.getTags(throttlesName),
             },
             {
                 parent: this,
@@ -254,8 +273,9 @@ export class MetricAlarms extends pulumi.ComponentResource {
             },
         )
 
+        const concurrentsName = `${name}-concurrents`
         new aws.cloudwatch.MetricAlarm(
-            `${name}-concurrents`,
+            concurrentsName,
             {
                 namespace: 'AWS/Lambda',
                 metricName: 'ConcurrentExecutions',
@@ -279,6 +299,7 @@ export class MetricAlarms extends pulumi.ComponentResource {
                 okActions: [args.snsTopicArn],
                 insufficientDataActions: [args.snsTopicArn],
                 treatMissingData: 'notBreaching',
+                tags: args.getTags(concurrentsName),
             },
             {
                 parent: this,

--- a/libs/pulumi-lambda/src/lib/metric-alarms.ts
+++ b/libs/pulumi-lambda/src/lib/metric-alarms.ts
@@ -17,11 +17,11 @@ export interface Thresholds {
     avgDurationMs?: pulumi.Input<number>
     /**
      * Alert if the max duration is greater than this
-     * Default: not used (undefined) if timeoutMs is set
+     * Default: not used (undefined)
      */
     maxDurationMs?: pulumi.Input<number>
     /**
-     * Alert if the max duration
+     * Alert if the max duration is greater than this
      * Default: not used (undefined)
      */
     timeoutMs?: pulumi.Input<number>
@@ -161,10 +161,7 @@ export class MetricAlarms extends pulumi.ComponentResource {
             },
         )
 
-        if (
-            args.thresholds?.maxDurationMs ??
-            args.thresholds?.timeoutMs === undefined
-        ) {
+        if (args.thresholds?.maxDurationMs) {
             new aws.cloudwatch.MetricAlarm(
                 `${name}-duration-max`,
                 {
@@ -198,7 +195,7 @@ export class MetricAlarms extends pulumi.ComponentResource {
             )
         }
 
-        if (args.thresholds?.timeoutMs !== undefined) {
+        if (args.thresholds?.timeoutMs) {
             new aws.cloudwatch.MetricAlarm(
                 `${name}-timeout`,
                 {


### PR DESCRIPTION
Add monitoring of the following metrics to pulumi-lambda:
* average/max duration
* timeout (calculated as max duration >= lambda timeout)
* error rate
* throttles
* concurrents
