### PR TITLE
fix missing runners for pr-test-on-reviewed workflow

### DIFF
--- a/.github/workflows/pr-test-on-reviewed.yml
+++ b/.github/workflows/pr-test-on-reviewed.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: github.event.review.state == 'approved'
     steps:
       - name: Repository Dispatch


### PR DESCRIPTION
It currently uses self-hosted, which isn't set up. Switch to ubuntu-latest