### PR TITLE
allow moving existing resources into this module without delete & recreate

### DIFF
--- a/.changeset/light-rice-laugh.md
+++ b/.changeset/light-rice-laugh.md
@@ -1,0 +1,5 @@
+---
+'@wanews/pulumi-lambda': minor
+---
+
+allow existing resources to be moved into this module using aliases


### PR DESCRIPTION
Some versions of pulumi and/or aws-sdk are unable to delete Log Groups resources. D:<

Add optional opts to allow adding existing resources as aliases.

As per https://www.pulumi.com/docs/intro/concepts/resources/#aliases