### PR TITLE
API Gateway metric alarms

### DIFF
--- a/.changeset/quick-beers-wave.md
+++ b/.changeset/quick-beers-wave.md
@@ -1,0 +1,5 @@
+---
+'@wanews/pulumi-apigateway-lambda-proxy': minor
+---
+
+add metric alarms for API Gateway

--- a/libs/apigateway-lambda-proxy/README.md
+++ b/libs/apigateway-lambda-proxy/README.md
@@ -107,25 +107,6 @@ new RecommendedAlarms('alarms', {
 })
 ```
 
-You can also set up monitoring of REST APIs, make sure you leave apiGateway.id undefined:
-
-```ts
-import * as aws from '@pulumi/aws'
-import { RecommendedAlarms } from '@wanews/pulumi-apigateway-lambda-proxy'
-
-const restApi = new aws.apigatewayv2.Api('apigw-http', {
-  /* ... */
-})
-
-new RecommendedAlarms('alarms', {
-  snsTopicArn: 'arn:aws:sns:<region>:<account>:<topic>',
-  apiGateway: {
-    name: restApi.name,
-    stage: gw.stage?.name,
-  },
-})
-```
-
 By default, the following metrics are monitored:
 
 - 5xx error rate

--- a/libs/apigateway-lambda-proxy/README.md
+++ b/libs/apigateway-lambda-proxy/README.md
@@ -134,7 +134,7 @@ new RecommendedAlarms('alarms', {
     stage: gw.stage?.name,
   },
   thresholds: {
-    errorRate5xxPercent: 0,
+    errorRate5xxPercent: 1,
   },
 })
 

--- a/libs/apigateway-lambda-proxy/README.md
+++ b/libs/apigateway-lambda-proxy/README.md
@@ -107,6 +107,10 @@ new RecommendedAlarms('alarms', {
 })
 ```
 
+Note that the name is only used for cosmetic purposes. You should set it to a value that easily identifies the API.
+
+Note that, despite REST APIs using name instead of id, this module does not support REST APIs, only HTTP APIs.
+
 By default, the following metrics are monitored:
 
 - 5xx error rate

--- a/libs/apigateway-lambda-proxy/README.md
+++ b/libs/apigateway-lambda-proxy/README.md
@@ -109,8 +109,6 @@ new RecommendedAlarms('alarms', {
 
 Note that the name is only used for cosmetic purposes. You should set it to a value that easily identifies the API.
 
-Note that, despite REST APIs using name instead of id, this module does not support REST APIs, only HTTP APIs.
-
 By default, the following metrics are monitored:
 
 - 5xx error rate

--- a/libs/apigateway-lambda-proxy/src/index.ts
+++ b/libs/apigateway-lambda-proxy/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/apigateway-lambda-proxy'
+export * from './lib/metric-alarms'

--- a/libs/apigateway-lambda-proxy/src/lib/metric-alarms.ts
+++ b/libs/apigateway-lambda-proxy/src/lib/metric-alarms.ts
@@ -29,32 +29,9 @@ export type HttpGateway = {
 }
 
 /**
- * Dimensions to identify a REST API in CloudWatch.
- *
- * The main difference is REST APIs are identified by name, while HTTP APIs are identified by id.
- */
-export type RestGateway = {
-    /**
-     * The API Gateway ID to monitor. Only valid for HTTP endpoints.
-     */
-    id: undefined
-
-    /**
-     * For REST endpoints, this must be the name of the API created in AWS.
-     * For HTTP endpoints, this can be anything (it's only used in alerts).
-     */
-    name: pulumi.Input<string>
-
-    /**
-     * The stage to monitor
-     */
-    stage?: pulumi.Input<string>
-}
-
-/**
  * Dimensions to identify an API in CloudWatch.
  */
-export type ApiGateway = HttpGateway | RestGateway
+export type ApiGateway = HttpGateway
 
 /**
  * Provides an opinionated set of recommended alarms for an API Gateway stage.

--- a/libs/apigateway-lambda-proxy/src/lib/metric-alarms.ts
+++ b/libs/apigateway-lambda-proxy/src/lib/metric-alarms.ts
@@ -13,13 +13,6 @@ export type HttpGateway = {
     id: pulumi.Input<string>
 
     /**
-     * The API name to monitor.
-     *
-     * For HTTP endpoints, this can be anything (it's only used in alerts).
-     */
-    name: pulumi.Input<string> | undefined
-
-    /**
      * The stage to monitor
      */
     stage?: pulumi.Input<string>
@@ -173,7 +166,7 @@ export class ErrorRate5xxAlarm extends pulumi.ComponentResource {
                 threshold,
                 statistic: 'Average',
                 alarmDescription: pulumi.interpolate`threshold: 5xx rate >= ${thresholdPercent}%: ${
-                    args.apiGateway.name ?? args.apiGateway.id
+                    args.apiGateway.id
                 }`,
                 alarmActions: [args.snsTopicArn],
                 okActions: [args.snsTopicArn],
@@ -204,7 +197,7 @@ export class ErrorRate4xxAlarm extends pulumi.ComponentResource {
             apiGateway: HttpGateway
             /**
              * Alert if the 4xx error rate exceeds this
-             * (default: 2 percent)
+             * (default: 50 percent)
              */
             errorRate4xxPercent?: pulumi.Input<number>
             /**
@@ -241,7 +234,7 @@ export class ErrorRate4xxAlarm extends pulumi.ComponentResource {
                 threshold,
                 statistic: 'Average',
                 alarmDescription: pulumi.interpolate`threshold: 4xx rate >= ${thresholdPercent}%: ${
-                    args.apiGateway.name ?? args.apiGateway.id
+                    args.apiGateway.id
                 }`,
                 alarmActions: [args.snsTopicArn],
                 okActions: [args.snsTopicArn],

--- a/libs/apigateway-lambda-proxy/src/lib/metric-alarms.ts
+++ b/libs/apigateway-lambda-proxy/src/lib/metric-alarms.ts
@@ -102,16 +102,14 @@ export class RecommendedAlarms extends pulumi.ComponentResource {
  * @returns the dimensions for passing to CloudWatch alarms
  */
 function getDimensions(api: HttpGateway) {
-    return pulumi
-        .all([api.id, api.name, api.stage])
-        .apply(([id, name, stage]) => ({
-            ApiId: id,
-            ...(stage
-                ? {
-                      Stage: stage,
-                  }
-                : {}),
-        }))
+    return pulumi.all([api.id, api.stage]).apply(([id, stage]) => ({
+        ApiId: id,
+        ...(stage
+            ? {
+                  Stage: stage,
+              }
+            : {}),
+    }))
 }
 
 /** raise an alarm if the 5xx error rate exceeds errorRate5xxPercent */
@@ -159,15 +157,13 @@ export class ErrorRate5xxAlarm extends pulumi.ComponentResource {
             {
                 evaluationPeriods: 2,
                 datapointsToAlarm: 2,
-                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                comparisonOperator: 'GreaterThanThreshold',
                 namespace,
                 metricName,
                 dimensions,
                 threshold,
                 statistic: 'Average',
-                alarmDescription: pulumi.interpolate`threshold: 5xx rate >= ${thresholdPercent}%: ${
-                    args.apiGateway.id
-                }`,
+                alarmDescription: pulumi.interpolate`threshold: 5xx rate >= ${thresholdPercent}%: ${args.apiGateway.id}`,
                 alarmActions: [args.snsTopicArn],
                 okActions: [args.snsTopicArn],
                 insufficientDataActions: [args.snsTopicArn],
@@ -227,15 +223,13 @@ export class ErrorRate4xxAlarm extends pulumi.ComponentResource {
             {
                 evaluationPeriods: 2,
                 datapointsToAlarm: 2,
-                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                comparisonOperator: 'GreaterThanThreshold',
                 namespace,
                 metricName,
                 dimensions,
                 threshold,
                 statistic: 'Average',
-                alarmDescription: pulumi.interpolate`threshold: 4xx rate >= ${thresholdPercent}%: ${
-                    args.apiGateway.id
-                }`,
+                alarmDescription: pulumi.interpolate`threshold: 4xx rate >= ${thresholdPercent}%: ${args.apiGateway.id}`,
                 alarmActions: [args.snsTopicArn],
                 okActions: [args.snsTopicArn],
                 insufficientDataActions: [args.snsTopicArn],
@@ -294,7 +288,7 @@ export class IntegrationLatencyAlarm extends pulumi.ComponentResource {
                 period: 60,
                 evaluationPeriods: 2,
                 datapointsToAlarm: 2,
-                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                comparisonOperator: 'GreaterThanUpperThreshold',
                 metricQueries: [
                     {
                         id: 'e1',
@@ -315,11 +309,7 @@ export class IntegrationLatencyAlarm extends pulumi.ComponentResource {
                     },
                 ],
                 thresholdMetricId: 'e1',
-                alarmDescription: pulumi.interpolate`anomaly: ${metricName} (${
-                    args.stdDeviations
-                } standard deviations): ${
-                    args.apiGateway.name ?? args.apiGateway.id
-                }`,
+                alarmDescription: pulumi.interpolate`anomaly: ${metricName} (${args.stdDeviations} standard deviations): ${args.apiGateway.id}`,
                 alarmActions: [args.snsTopicArn],
                 okActions: [args.snsTopicArn],
                 insufficientDataActions: [args.snsTopicArn],

--- a/libs/apigateway-lambda-proxy/src/lib/metric-alarms.ts
+++ b/libs/apigateway-lambda-proxy/src/lib/metric-alarms.ts
@@ -1,0 +1,399 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as aws from '@pulumi/aws'
+
+const namespace = 'AWS/ApiGateway'
+
+/**
+ * Dimensions to identify an HTTP API in CloudWatch.
+ *
+ * The main difference is REST APIs are identified by name, while HTTP APIs are identified by id.
+ */
+export type HttpGateway = {
+    /**
+     * The API Gateway ID to monitor. Only valid for HTTP endpoints.
+     */
+    id: pulumi.Input<string>
+
+    /**
+     * The API name to monitor.
+     *
+     * For REST endpoints, this must be the name of the API created in AWS.
+     * For HTTP endpoints, this can be anything (it's only used in alerts).
+     */
+    name: pulumi.Input<string> | undefined
+
+    /**
+     * The stage to monitor
+     */
+    stage?: pulumi.Input<string>
+}
+
+/**
+ * Dimensions to identify a REST API in CloudWatch.
+ *
+ * The main difference is REST APIs are identified by name, while HTTP APIs are identified by id.
+ */
+export type RestGateway = {
+    /**
+     * The API Gateway ID to monitor. Only valid for HTTP endpoints.
+     */
+    id: undefined
+
+    /**
+     * For REST endpoints, this must be the name of the API created in AWS.
+     * For HTTP endpoints, this can be anything (it's only used in alerts).
+     */
+    name: pulumi.Input<string>
+
+    /**
+     * The stage to monitor
+     */
+    stage?: pulumi.Input<string>
+}
+
+/**
+ * Dimensions to identify an API in CloudWatch.
+ */
+export type ApiGateway = HttpGateway | RestGateway
+
+/**
+ * Provides an opinionated set of recommended alarms for an API Gateway stage.
+ *
+ * Raise alarms for the following:
+ *  - 5xx error rate exceeded (default: 2%)
+ *  - 4xx error rate exceeded (default: 50%)
+ *  - integration latency too high (anomaly detection)
+ */
+export class RecommendedAlarms extends pulumi.ComponentResource {
+    constructor(
+        name: string,
+        args: {
+            /**
+             * Alerts will be sent to this SNS topic
+             */
+            snsTopicArn: pulumi.Input<string>
+            /**
+             * Set thresholds for the alarms
+             */
+            thresholds?: {
+                errorRate5xxPercent?: pulumi.Input<number>
+                errorRate4xxPercent?: pulumi.Input<number>
+                integrationLatencyStdDeviations?: pulumi.Input<number>
+            }
+            /**
+             * The API Gateway to monitor
+             */
+            apiGateway: ApiGateway
+            /**
+             * a callback function that returns tags for
+             * each resource
+             */
+            getTags: (
+                name: string,
+            ) => {
+                [key: string]: pulumi.Input<string>
+            }
+        },
+        opts?: pulumi.ComponentResourceOptions,
+    ) {
+        super('wanews:apigateway/RecommendedAlarms', name, {}, opts)
+
+        new ErrorRate5xxAlarm(
+            name,
+            {
+                snsTopicArn: args.snsTopicArn,
+                apiGateway: args.apiGateway,
+                getTags: args.getTags,
+                errorRate5xxPercent: args.thresholds?.errorRate5xxPercent,
+            },
+            { parent: this },
+        )
+
+        new ErrorRate4xxAlarm(
+            name,
+            {
+                snsTopicArn: args.snsTopicArn,
+                apiGateway: args.apiGateway,
+                getTags: args.getTags,
+                errorRate4xxPercent: args.thresholds?.errorRate4xxPercent,
+            },
+            { parent: this },
+        )
+
+        new IntegrationLatencyAlarm(
+            name,
+            {
+                snsTopicArn: args.snsTopicArn,
+                apiGateway: args.apiGateway,
+                getTags: args.getTags,
+                stdDeviations: args.thresholds?.integrationLatencyStdDeviations,
+            },
+            { parent: this },
+        )
+    }
+}
+
+/**
+ * Check if an ApiGateway is a REST API
+ *
+ * @param api the APIGateway to test
+ * @returns true if api.id is undefined
+ */
+function isRestApi(api: ApiGateway) {
+    return api.id === undefined
+}
+
+/**
+ * Check if an ApiGateway is an HTTP API
+ *
+ * @param api the APIGateway to test
+ * @returns true if api.id is defined
+ */
+function isHttpApi(api: ApiGateway) {
+    return !isRestApi(api)
+}
+
+/**
+ * Get dimensions for a cloudwatch alarm
+ *
+ * @param api the APIGateway to test
+ * @returns the dimensions for passing to CloudWatch alarms
+ */
+function getDimensions(api: ApiGateway) {
+    return pulumi
+        .all([api.id, api.name, api.stage])
+        .apply(([id, name, stage]) => ({
+            ...(isHttpApi(api)
+                ? {
+                      ApiId: id,
+                  }
+                : {
+                      ApiName: name,
+                  }),
+            ...(stage
+                ? {
+                      Stage: stage,
+                  }
+                : {}),
+        }))
+}
+
+/** raise an alarm if the 5xx error rate exceeds errorRate5xxPercent */
+export class ErrorRate5xxAlarm extends pulumi.ComponentResource {
+    constructor(
+        name: string,
+        args: {
+            /**
+             * Alerts will be sent to this SNS topic
+             */
+            snsTopicArn: pulumi.Input<string>
+            /**
+             * The API Gateway to monitor
+             */
+            apiGateway: ApiGateway
+            /**
+             * Alert if the 5xx error rate exceeds this
+             * (default: 2 percent)
+             */
+            errorRate5xxPercent?: pulumi.Input<number>
+            /**
+             * a callback function that returns tags for
+             * each resource
+             */
+            getTags: (
+                name: string,
+            ) => {
+                [key: string]: pulumi.Input<string>
+            }
+        },
+        opts?: pulumi.ComponentResourceOptions,
+    ) {
+        super('wanews:apigateway/ErrorRate5xxAlarm', name, {}, opts)
+
+        const metricName = isHttpApi(args.apiGateway) ? '5xx' : '5XXError'
+        const dimensions = getDimensions(args.apiGateway)
+        const thresholdPercent = args.errorRate5xxPercent ?? 2
+        const threshold = pulumi
+            .output(thresholdPercent)
+            .apply((percent) => percent / 100)
+        const resourceName = `${name}-5xx-rate`
+
+        new aws.cloudwatch.MetricAlarm(
+            resourceName,
+            {
+                evaluationPeriods: 2,
+                datapointsToAlarm: 2,
+                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                namespace,
+                metricName,
+                dimensions,
+                threshold,
+                statistic: 'Average',
+                alarmDescription: pulumi.interpolate`threshold: 5xx rate >= ${thresholdPercent}%: ${
+                    args.apiGateway.name ?? args.apiGateway.id
+                }`,
+                alarmActions: [args.snsTopicArn],
+                okActions: [args.snsTopicArn],
+                insufficientDataActions: [args.snsTopicArn],
+                treatMissingData: 'notBreaching',
+                tags: args.getTags(resourceName),
+            },
+            {
+                parent: this,
+                deleteBeforeReplace: true,
+            },
+        )
+    }
+}
+
+/** raise an alarm if the 4xx error rate exceeds errorRate4xxPercent */
+export class ErrorRate4xxAlarm extends pulumi.ComponentResource {
+    constructor(
+        name: string,
+        args: {
+            /**
+             * Alerts will be sent to this SNS topic
+             */
+            snsTopicArn: pulumi.Input<string>
+            /**
+             * The API Gateway to monitor
+             */
+            apiGateway: ApiGateway
+            /**
+             * Alert if the 4xx error rate exceeds this
+             * (default: 2 percent)
+             */
+            errorRate4xxPercent?: pulumi.Input<number>
+            /**
+             * a callback function that returns tags for
+             * each resource
+             */
+            getTags: (
+                name: string,
+            ) => {
+                [key: string]: pulumi.Input<string>
+            }
+        },
+        opts?: pulumi.ComponentResourceOptions,
+    ) {
+        super('wanews:apigateway/ErrorRate4xxAlarm', name, {}, opts)
+
+        const metricName = isHttpApi(args.apiGateway) ? '4xx' : '4XXError'
+        const dimensions = getDimensions(args.apiGateway)
+        const thresholdPercent = args.errorRate4xxPercent ?? 50
+        const threshold = pulumi
+            .output(thresholdPercent)
+            .apply((percent) => percent / 100)
+        const resourceName = `${name}-4xx-rate`
+
+        new aws.cloudwatch.MetricAlarm(
+            resourceName,
+            {
+                evaluationPeriods: 2,
+                datapointsToAlarm: 2,
+                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                namespace,
+                metricName,
+                dimensions,
+                threshold,
+                statistic: 'Average',
+                alarmDescription: pulumi.interpolate`threshold: 4xx rate >= ${thresholdPercent}%: ${
+                    args.apiGateway.name ?? args.apiGateway.id
+                }`,
+                alarmActions: [args.snsTopicArn],
+                okActions: [args.snsTopicArn],
+                insufficientDataActions: [args.snsTopicArn],
+                treatMissingData: 'notBreaching',
+                tags: args.getTags(resourceName),
+            },
+            {
+                parent: this,
+                deleteBeforeReplace: true,
+            },
+        )
+    }
+}
+
+/** raise an alarm if integration latency is too high */
+export class IntegrationLatencyAlarm extends pulumi.ComponentResource {
+    constructor(
+        name: string,
+        args: {
+            /**
+             * Alerts will be sent to this SNS topic
+             */
+            snsTopicArn: pulumi.Input<string>
+            /**
+             * The API Gateway to monitor
+             */
+            apiGateway: ApiGateway
+            /**
+             * The number of standard deviations to use for the anomaly detection.
+             *
+             * Default: 5
+             */
+            stdDeviations?: pulumi.Input<number>
+            /**
+             * a callback function that returns tags for
+             * each resource
+             */
+            getTags: (
+                name: string,
+            ) => {
+                [key: string]: pulumi.Input<string>
+            }
+        },
+        opts?: pulumi.ComponentResourceOptions,
+    ) {
+        super('wanews:apigateway/IntegrationLatencyAlarm', name, {}, opts)
+
+        const resourceName = `${name}-integration-latency`
+        const metricName = 'IntegrationLatency'
+        const dimensions = getDimensions(args.apiGateway)
+        args.stdDeviations = args.stdDeviations ?? 5
+
+        new aws.cloudwatch.MetricAlarm(
+            resourceName,
+            {
+                period: 60,
+                evaluationPeriods: 2,
+                datapointsToAlarm: 2,
+                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                metricQueries: [
+                    {
+                        id: 'e1',
+                        expression: pulumi.interpolate`ANOMALY_DETECTION_BAND(m1, ${args.stdDeviations})`,
+                        label: `${metricName} (expected)`,
+                        returnData: true,
+                    },
+                    {
+                        id: 'm1',
+                        returnData: false,
+                        metric: {
+                            metricName,
+                            dimensions,
+                            namespace,
+                            stat: 'Average',
+                            period: 60,
+                        },
+                    },
+                ],
+                thresholdMetricId: 'e1',
+                alarmDescription: pulumi.interpolate`anomaly: ${metricName} (${
+                    args.stdDeviations
+                } standard deviations): ${
+                    args.apiGateway.name ?? args.apiGateway.id
+                }`,
+                alarmActions: [args.snsTopicArn],
+                okActions: [args.snsTopicArn],
+                insufficientDataActions: [args.snsTopicArn],
+                treatMissingData: 'notBreaching',
+                tags: args.getTags(resourceName),
+            },
+            {
+                parent: this,
+                deleteBeforeReplace: true,
+            },
+        )
+    }
+}


### PR DESCRIPTION
Add metric alarms to `@wanews/pulumi-apigateway-lambda-proxy`. Can be used with resources created by this package, or with HTTP/REST APIs created externally. Usage examples can be found in README.md. 