### PR TITLE
Fix ConflictsWith error in IntegrationLatency metric alarm

### DIFF
--- a/.changeset/tough-jokes-pay.md
+++ b/.changeset/tough-jokes-pay.md
@@ -1,0 +1,5 @@
+---
+'@wanews/pulumi-apigateway-lambda-proxy': minor
+---
+
+fix ConflictsWith error in @wanews/pulumi-apigateway-lambda-proxy

--- a/libs/apigateway-lambda-proxy/package.json
+++ b/libs/apigateway-lambda-proxy/package.json
@@ -15,5 +15,8 @@
     "bugs": {
         "url": "https://github.com/sevenwestmedia-labs/pulumi-components/issues"
     },
-    "homepage": "https://github.com/sevenwestmedia-labs/pulumi-components/tree/master/libs/apigateway-lambda-proxy#readme"
+    "homepage": "https://github.com/sevenwestmedia-labs/pulumi-components/tree/master/libs/apigateway-lambda-proxy#readme",
+    "dependencies": {
+        "@wanews/pulumi-lambda": "0.9.0"
+    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,7 +84,10 @@ importers:
       typescript: 4.2.4
 
   libs/apigateway-lambda-proxy:
-    specifiers: {}
+    specifiers:
+      '@wanews/pulumi-lambda': 0.9.0
+    dependencies:
+      '@wanews/pulumi-lambda': 0.9.0
 
   libs/buildstep:
     specifiers: {}
@@ -1842,7 +1845,7 @@ packages:
     dev: false
 
   /@pulumi/query/0.3.0:
-    resolution: {integrity: sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w==}
+    resolution: {integrity: sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w==, tarball: '@pulumi/query/-/query-0.3.0.tgz'}
 
   /@pulumi/random/4.0.0:
     resolution: {integrity: sha512-ZjCmHVOLfzkzRvbpa9RtLfYobStq8LhWcjCvjSjOOJZAgBrMkl3CJYnFdrr/DEqrTwQ5HJnG8jU/StOkOQka3g==, tarball: '@pulumi/random/-/random-4.0.0.tgz'}
@@ -2111,6 +2114,10 @@ packages:
       '@types/fs-extra': 9.0.11
       execa: 5.0.0
     dev: true
+
+  /@wanews/pulumi-lambda/0.9.0:
+    resolution: {integrity: sha512-zCXqYyJCMA2SbA/H8Cll/jSr5KYdASGsdThZVeqpnbj3MZEbBrAxDfqSP5Ge/fcbBZO7QnrTLE7422x77eyzeg==}
+    dev: false
 
   /abab/2.0.5:
     resolution: {integrity: sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,7 +87,7 @@ importers:
     specifiers:
       '@wanews/pulumi-lambda': 0.9.0
     dependencies:
-      '@wanews/pulumi-lambda': 0.9.0
+      '@wanews/pulumi-lambda': link:../pulumi-lambda
 
   libs/buildstep:
     specifiers: {}
@@ -2114,10 +2114,6 @@ packages:
       '@types/fs-extra': 9.0.11
       execa: 5.0.0
     dev: true
-
-  /@wanews/pulumi-lambda/0.9.0:
-    resolution: {integrity: sha512-zCXqYyJCMA2SbA/H8Cll/jSr5KYdASGsdThZVeqpnbj3MZEbBrAxDfqSP5Ge/fcbBZO7QnrTLE7422x77eyzeg==}
-    dev: false
 
   /abab/2.0.5:
     resolution: {integrity: sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==}


### PR DESCRIPTION
Newer versions of the aws API prevent `Period` from being used with `Metrics`. However, `Period` was required (and silently ignored) in older versions of terraform.

This is no longer the case in the current version of pulumi, and instead it causes a ConflictsWith error as expected.

This PR removes the top-level `Period` parameter to fix the error.

Also included:
* fix `alarmDescription` fields using `>=` instead of `>` where `GreaterThanThreshold` is used &mdash; https://github.com/sevenwestmedia-labs/pulumi-components/pull/30#discussion_r651413615
* add missing dependency to `@wanews/pulumi-apigateway-lambda-proxy`