### PR TITLE
Allow clients to set an execution role

### DIFF
--- a/.changeset/six-plants-work.md
+++ b/.changeset/six-plants-work.md
@@ -1,0 +1,5 @@
+---
+'@wanews/pulumi-apigateway-lambda-proxy': minor
+---
+
+Allow clients to set an execution role on lambda proxy

--- a/libs/apigateway-lambda-proxy/README.md
+++ b/libs/apigateway-lambda-proxy/README.md
@@ -39,7 +39,7 @@ const cert = new Certificate(`${name}-cert`, {
 })
 
 // Get the route53 zone
-const zone = pulumi.output(aws.route53.getZone({ name: 'customdomain.net' }))
+const zoneId = pulumi.output(aws.route53.getZone({ name: 'customdomain.net' }))
   .zoneId
 
 // Use @wanews/pulumi-certificate-validation to perform dns validation
@@ -53,9 +53,19 @@ const validCertificate = new ValidateCertificate(`cert-validation`, {
   ],
 })
 
+function getTags(name: string) {
+    // Use whatever logic you like to construct your tags
+    return {
+      Name: name,
+      Product: 'my-product',
+      /* ... */
+    }
+}
+
 new ApiGatewayLambdaProxy(`my-api`, {
   hostname: 'my.customdomain.net',
   apiGatewayCertificateArn: validCertificate.validCertificateArn,
+  getTags,
 
   lambdaOptions: {
     code: new pulumi.asset.FileArchive('path/to/code/'),

--- a/libs/apigateway-lambda-proxy/src/lib/apigateway-lambda-proxy.ts
+++ b/libs/apigateway-lambda-proxy/src/lib/apigateway-lambda-proxy.ts
@@ -19,6 +19,8 @@ export class ApiGatewayLambdaProxy extends pulumi.ComponentResource {
             hostname,
 
             lambdaOptions,
+            executionRoleName,
+            executionRole,
             apiGatewayOptions = {},
             getTags,
 
@@ -39,6 +41,14 @@ export class ApiGatewayLambdaProxy extends pulumi.ComponentResource {
                 aws.apigatewayv2.ApiArgs,
                 'protocolType' | 'tags'
             >
+
+            /**
+             * Role must already exist, otherwise preview will fail
+             *
+             * If you are creating the role in the same program, use executionRole
+             */
+            executionRoleName?: string;
+            executionRole?: aws.iam.Role;
 
             /** Callback to create tags for the resources created */
             getTags: (
@@ -85,6 +95,8 @@ export class ApiGatewayLambdaProxy extends pulumi.ComponentResource {
             {
                 getTags,
                 lambdaOptions,
+                executionRole,
+                executionRoleName,
             },
             { parent: this },
         )


### PR DESCRIPTION
Clients may need to give their lambda proxy a specific execution role with specific policy attachments.

This PR allows them to do so.