### PR TITLE
Update cloudfront.ts

### DIFF
--- a/.changeset/hot-spoons-glow.md
+++ b/.changeset/hot-spoons-glow.md
@@ -1,0 +1,5 @@
+---
+'@wanews/pulumi-static-site': patch
+---
+
+Removed hard coded webAclId and added `distributionIgnoreChanges`

--- a/libs/pulumi-static-site/src/cloudfront.ts
+++ b/libs/pulumi-static-site/src/cloudfront.ts
@@ -10,9 +10,6 @@ const managedCorsS3OriginRequestPolicyId =
 const managedCachingOptimizedCachePolicyId =
     '658327ea-f89d-4fab-a63d-7e88639e58f6'
 
-const defaultManagedWebAcl =
-    'FMManagedWebACLe21c2ecb-0057-4788-a990-0c79c9b05254'
-
 export interface CfDistributionOptions {
     priceClass?: pulumi.Input<string>
     cachePolicyId?: pulumi.Input<string>
@@ -41,7 +38,9 @@ export class Distribution extends pulumi.ComponentResource {
     constructor(
         name: string,
         args: DistributionArgs,
-        opts?: pulumi.ComponentResourceOptions,
+        opts?: pulumi.ComponentResourceOptions & {
+            distributionIgnoreChanges?: pulumi.ComponentResourceOptions['ignoreChanges']
+        },
     ) {
         super(
             'swm:pulumi-static-site:distribution/Distribution',
@@ -106,20 +105,13 @@ export class Distribution extends pulumi.ComponentResource {
                     minimumProtocolVersion: 'TLSv1.2_2019',
                     sslSupportMethod: 'sni-only',
                 },
-                webAclId:
-                    args.webAclId ??
-                    pulumi.output(
-                        aws.waf.getWebAcl(
-                            { name: defaultManagedWebAcl },
-                            { parent: this },
-                        ),
-                    ).id,
+                webAclId: args.webAclId,
                 comment: pulumi.interpolate`Static Site Distribution for ${pulumi
                     .output(args.domains)
                     .apply((domains) => domains.join(', '))}`,
                 tags: args.getTags(name),
             },
-            { parent: this },
+            { parent: this, ignoreChanges: opts?.distributionIgnoreChanges },
         )
     }
 }

--- a/libs/pulumi-static-site/src/static-site.ts
+++ b/libs/pulumi-static-site/src/static-site.ts
@@ -27,6 +27,7 @@ export class StaticSite extends pulumi.ComponentResource {
         name: string,
         args: StaticSiteArgs,
         opts?: pulumi.ComponentResourceOptions & {
+            distributionIgnoreChanges?: pulumi.ComponentResourceOptions['ignoreChanges']
             providerUsEast1?: pulumi.ProviderResource
         },
     ) {
@@ -108,7 +109,10 @@ export class StaticSite extends pulumi.ComponentResource {
                 refererValue: refererSecret.result,
                 getTags: args.getTags,
             },
-            { parent: this },
+            {
+                parent: this,
+                distributionIgnoreChanges: opts?.distributionIgnoreChanges,
+            },
         ).distribution
 
         // Add DNS records for the domain to point to the CF distribution


### PR DESCRIPTION
The hardcoded webAclId is specific to SWM, it'll just cause errors if used outside our AWS org.

Use `ignoreChanges` instead.