### PR TITLE
Extended pulumi-static-site pulumi inputs

### DIFF
--- a/.changeset/strange-ears-tie.md
+++ b/.changeset/strange-ears-tie.md
@@ -1,0 +1,7 @@
+---
+'@wanews/pulumi-static-site': patch
+---
+
+`bucketOptions` pulumi input accepts every aws.s3.Bucket pulumi input
+Added `additionalOrigins` and `orderedCacheBehaviours` options to the `distributionOptions` pulumi input
+Added aliases for the route53 records for easy module migrations

--- a/libs/pulumi-static-site/src/static-site.ts
+++ b/libs/pulumi-static-site/src/static-site.ts
@@ -28,6 +28,8 @@ export class StaticSite extends pulumi.ComponentResource {
         args: StaticSiteArgs,
         opts?: pulumi.ComponentResourceOptions & {
             providerUsEast1?: pulumi.ProviderResource
+            route53DnsARecordAliases?: pulumi.ComponentResourceOptions['aliases']
+            route53DnsAAAARecordAliases?: pulumi.ComponentResourceOptions['aliases']
         },
     ) {
         super('swm:pulumi-static-site:static-site/StaticSite', name, {}, opts)
@@ -126,7 +128,7 @@ export class StaticSite extends pulumi.ComponentResource {
                 ],
                 zoneId: primaryDomainZone.id,
             },
-            { parent: this },
+            { parent: this, aliases: opts?.route53DnsARecordAliases },
         )
 
         new aws.route53.Record(
@@ -143,7 +145,7 @@ export class StaticSite extends pulumi.ComponentResource {
                 ],
                 zoneId: primaryDomainZone.id,
             },
-            { parent: this },
+            { parent: this, aliases: opts?.route53DnsAAAARecordAliases },
         )
     }
 }


### PR DESCRIPTION
- `bucketOptions` accepts all inputs of `aws.s3.Bucket`
- `additionalOrigins` and `orderedCacheBehaviours` added to `distributionOptions`
- Aliases used for route53 dns records