### PR TITLE
Set timeout in ECS waiter and surface error conditions

### DIFF
--- a/.changeset/beige-news-unite.md
+++ b/.changeset/beige-news-unite.md
@@ -1,0 +1,6 @@
+---
+'@wanews/pulumi-wait-for-ecs-deploy': patch
+---
+
+Fixed an issue where the wait for servicesStable ECS API call times out before the timeoutMs
+Display error messages raised from the dynamic provider

--- a/libs/wait-for-ecs-deploy/package.json
+++ b/libs/wait-for-ecs-deploy/package.json
@@ -2,6 +2,7 @@
     "name": "@wanews/pulumi-wait-for-ecs-deploy",
     "version": "0.2.0",
     "main": "dist/index.js",
+    "module": "dist/esm/index.js",
     "author": "Seven West Media WA",
     "license": "MIT",
     "repository": {


### PR DESCRIPTION
This fixes 2 issues with `wait-for-ecs-deploy`:

1. Error messages from `waitForService` aren't surfaced properly. They show up as below:
```
Diagnostics:
  pulumi-nodejs:dynamic:Resource (xxxxxxxxxxx-service-wait-for-deployment):
    error: undefined
```
This is fixed by throwing JS `Error`

2. The ECS `servicesStable` waiter by default calls the describeTasks() operation every 6 seconds (at most 100 times), therefore if the `timeoutMs` is more than 10 minutes it is never honored. 
This is fixed by setting the `maxAttempts` in the `$waiter` config based on the `timeoutMs`.

The `Promise.race` with the timeout is unnecessary since setting the `$waiter` config in `ecs.waitFor` will perform the expected behaviour. An example of it reaching the timeout
```
Diagnostics:
  pulumi-nodejs:dynamic:Resource (xxxxxxxxxxxxx-service-wait-for-deployment):
    error: Resource is not in the state servicesStable
```

