### PR TITLE
Add permittedAccounts to Bucket Options

### DIFF
--- a/.changeset/friendly-cups-work.md
+++ b/.changeset/friendly-cups-work.md
@@ -1,0 +1,21 @@
+---
+'@wanews/pulumi-static-site': minor
+'sample-pulumi-static-site': patch
+---
+
+Add permittedAccounts to S3BucketOptions
+
+Usage:
+
+```
+new Bucket('bucket', {
+   ...
+   bucketOptions: {
+     pertmittedAccounts: [
+       '11111111',
+       '22222222',
+     ],
+   },
+})
+```
+

--- a/.changeset/real-tips-attack.md
+++ b/.changeset/real-tips-attack.md
@@ -1,0 +1,5 @@
+---
+'@wanews/pulumi-static-site': minor
+---
+
+allow bucket ownership to be set to BucketOwnerPreferred

--- a/libs/pulumi-static-site/src/bucket.ts
+++ b/libs/pulumi-static-site/src/bucket.ts
@@ -1,10 +1,30 @@
 import * as aws from '@pulumi/aws'
 import * as pulumi from '@pulumi/pulumi'
 
-export type S3BucketOptions = Partial<Omit<aws.s3.BucketArgs, 'tags'>>
+export type S3BucketOptions = Partial<Omit<aws.s3.BucketArgs, 'tags'>> & {
+    /**
+     * A list of account numbers which need access to the bucket.
+     * Example: ['11111111', '22222222', ...]
+     *
+     * Accounts in this list will be allowed to use IAM to grant access to
+     * resources in this bucket.
+     *
+     * Note that any accounts NOT in this list will be unable to perform
+     * s3:GetObject, even if they would be otherwise permitted by ACLs, UNLESS
+     * the request includes a Referer header containing refererValue.
+     */
+    permittedAccounts?: pulumi.Input<string[]>
+}
 
 interface BucketArgs extends S3BucketOptions {
+    /**
+     * All s3:GetObject requests will be denied unless the request includes
+     * a Referer header containing this value.
+     *
+     * This does not apply to accounts listed in permittedAccounts.
+     */
     refererValue: pulumi.Input<string>
+
     getTags: (
         name: string,
     ) => {
@@ -38,8 +58,8 @@ export class Bucket extends pulumi.ComponentResource {
         )
 
         const policy = pulumi
-            .all([this.bucket.arn, refererValue])
-            .apply(([bucketArn, refererValue]) =>
+            .all([this.bucket.arn, refererValue, args.permittedAccounts])
+            .apply(([bucketArn, refererValue, permittedAccounts]) =>
                 aws.iam.getPolicyDocument(
                     {
                         version: '2012-10-17',
@@ -56,8 +76,45 @@ export class Bucket extends pulumi.ComponentResource {
                                         variable: 'aws:Referer',
                                         values: [refererValue],
                                     },
+                                    ...((permittedAccounts ?? []).length > 0
+                                        ? [
+                                              {
+                                                  test: 'StringNotEquals',
+                                                  variable: 'aws:SourceAccount',
+                                                  values: permittedAccounts,
+                                              },
+                                          ]
+                                        : []),
                                 ],
                             },
+                            ...((permittedAccounts ?? []).length > 0
+                                ? [
+                                      {
+                                          sid: 'AllowIAMAccessToBucket',
+                                          effect: 'Allow',
+                                          principals: [
+                                              {
+                                                  type: 'AWS',
+                                                  identifiers: permittedAccounts,
+                                              },
+                                          ],
+                                          actions: ['s3:*'],
+                                          resources: [`${bucketArn}/*`],
+                                      },
+                                      {
+                                          sid: 'AllowIAMAccessToListBucket',
+                                          effect: 'Allow',
+                                          principals: [
+                                              {
+                                                  type: 'AWS',
+                                                  identifiers: permittedAccounts,
+                                              },
+                                          ],
+                                          actions: ['s3:ListBucket'],
+                                          resources: [bucketArn],
+                                      },
+                                  ]
+                                : []),
                         ],
                     },
                     { parent: this },


### PR DESCRIPTION
currently, the S3 bucket policy does not permit anything. It only denies `s3:GetObject` unless the expected Referer is included in the request headers.

This makes it difficult to use third-party tools that expect `s3:GetObject` to work without this header. This even overrides object ACLs.

In this PR:
* add a new bucket option with a list of permitted accounts
* permitted accounts are added to the bucket policy, to allow policies to be defined using IAM
* permitted accounts are also excluded from the requirement to include the expected Referer in the request header of `s3:GetObject` requests
* also: allow BucketOwnerPreferred to be set on the bucket