### PR TITLE
fix conflicting operation error

### DIFF
--- a/.changeset/tasty-houses-mix.md
+++ b/.changeset/tasty-houses-mix.md
@@ -1,0 +1,5 @@
+---
+'@wanews/pulumi-static-site': patch
+---
+
+Fix conflicting operation error when bucket policy and ownership controls are applied simultaneously


### PR DESCRIPTION
When the bucket policy and ownership controls are changed at the same time, the following error occurs

```
OperationAborted: A conflicting conditional operation is currently in progress against this resource. Please try again.
```

Attempt to perform these operations sequentially.