### PR TITLE
Fix permitted accounts when request header does not contain Referer

### DIFF
--- a/.changeset/stale-penguins-melt.md
+++ b/.changeset/stale-penguins-melt.md
@@ -1,0 +1,6 @@
+---
+'@wanews/pulumi-static-site': minor
+'sample-pulumi-static-site': patch
+---
+
+allow overriding bucket policy to make the Referer Allowed instead of Deny


### PR DESCRIPTION
This PR allows overriding the default bucket policy to allow anonymous requests with the correct Referer.

For backwards compatibility, the default behaviour is unchanged:

```json
{
    "Sid": "AllowCloudFrontReadGetObject",
    "Effect": "Deny",
    "Principal": "*",
    "Action": "s3:GetObject",
    "Resource": "arn:aws:s3:::<bucket>/*",
    "Condition": {
        "StringNotEquals": {
            "aws:Referer": "<secret>"
        }
    }
}
```

However, this breaks authenticated requests, including those in `permittedAccounts`.

To override this, you can now set `alwaysDenyBadReferer: false` in the bucket options. This will change the policy to Allow all requests (including anonymous) if the Referer is set correctly:

```json
{
    "Sid": "AllowCloudFrontReadGetObject",
    "Effect": "Allow",
    "Principal": "*",
    "Action": "s3:GetObject",
    "Resource": "arn:aws:s3:::<bucket>/*",
    "Condition": {
        "StringEquals": {
            "aws:Referer": "<secret>"
        }
    }
}
```
