### PR TITLE
Allowing responseHeadersPolicyID to be passed to Cloudfront distribution inside StaticSite class

### DIFF
--- a/.changeset/weak-hairs-repair.md
+++ b/.changeset/weak-hairs-repair.md
@@ -1,0 +1,5 @@
+---
+'@wanews/pulumi-static-site': minor
+---
+
+Added responseHeadersPolicyId

--- a/libs/pulumi-static-site/src/cloudfront.ts
+++ b/libs/pulumi-static-site/src/cloudfront.ts
@@ -14,6 +14,7 @@ export interface CfDistributionOptions {
     priceClass?: pulumi.Input<string>
     cachePolicyId?: pulumi.Input<string>
     originRequestPolicyId?: pulumi.Input<string>
+    responseHeadersPolicyId?: pulumi.Input<string>
     webAclId?: pulumi.Input<string>
     lambdaFunctionAssociations?: pulumi.Input<
         pulumi.Input<aws.types.input.cloudfront.DistributionDefaultCacheBehaviorLambdaFunctionAssociation>[]
@@ -103,6 +104,8 @@ export class Distribution extends pulumi.ComponentResource {
                         args.originRequestPolicyId ??
                         managedCorsS3OriginRequestPolicyId,
                     lambdaFunctionAssociations: args.lambdaFunctionAssociations,
+                    responseHeadersPolicyId: args.responseHeadersPolicyId,
+                    
                 },
                 orderedCacheBehaviors: args.orderedCacheBehaviors,
                 restrictions: {
@@ -123,5 +126,6 @@ export class Distribution extends pulumi.ComponentResource {
             },
             { parent: this, ignoreChanges: opts?.distributionIgnoreChanges },
         )
+
     }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "@nrwl/linter": "12.0.8",
         "@nrwl/tao": "12.0.8",
         "@nrwl/workspace": "12.0.8",
-        "@pulumi/aws": "^4.0.0",
+        "@pulumi/aws": "^4.1.0",
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/pagerduty": "^2.2.0",
         "@types/debug": "^4.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
       '@nrwl/linter': 12.0.8
       '@nrwl/tao': 12.0.8
       '@nrwl/workspace': 12.0.8
-      '@pulumi/aws': ^4.0.0
+      '@pulumi/aws': ^4.1.0
       '@pulumi/pagerduty': ^2.2.0
       '@pulumi/pulumi': ^3.0.0
       '@pulumi/random': ^4.0.0
@@ -59,7 +59,7 @@ importers:
       '@nrwl/linter': 12.0.8
       '@nrwl/tao': 12.0.8
       '@nrwl/workspace': 12.0.8_debug@4.3.1+prettier@2.2.1
-      '@pulumi/aws': 4.0.0
+      '@pulumi/aws': 4.38.1
       '@pulumi/pagerduty': 2.2.0
       '@pulumi/pulumi': 3.0.0
       '@types/debug': 4.1.5
@@ -1780,22 +1780,20 @@ packages:
   /@protobufjs/utf8/1.1.0:
     resolution: {integrity: sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=}
 
-  /@pulumi/aws/4.0.0:
-    resolution: {integrity: sha512-zW4EiJhR09Mu6nwF4GUjRwQuA0l1RU2KyPM/JEOOCRh1FCpUvMu+mP+Iuv2R8CQgI7G2gkkEuMRmV08e5u9DEQ==, tarball: '@pulumi/aws/-/aws-4.0.0.tgz'}
+  /@pulumi/aws/4.38.1:
+    resolution: {integrity: sha512-WeOprXm/c9n8QmP5qLNEVk1FZTCa7KGgUj/P1drlazJr1LIvrq+KSWcUxayLeFJvpLCbYd19aI2jdyQqZJAjEw==}
     requiresBuild: true
     dependencies:
-      '@pulumi/pulumi': 3.0.0
+      '@pulumi/pulumi': 3.3.0
       aws-sdk: 2.889.0
       builtin-modules: 3.0.0
       mime: 2.5.2
       read-package-tree: 5.3.1
       resolve: 1.20.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@pulumi/pagerduty/2.2.0:
-    resolution: {integrity: sha512-fEc+1DshCIerGOEl3XSGDuU/YQHFP2qw5DQ2dyjpgeqwiZ3Az+Cp9H9bKy8VHPh4q3a5L9N/KG1ilpwBM9FAYQ==, tarball: '@pulumi/pagerduty/-/pagerduty-2.2.0.tgz'}
+    resolution: {integrity: sha512-fEc+1DshCIerGOEl3XSGDuU/YQHFP2qw5DQ2dyjpgeqwiZ3Az+Cp9H9bKy8VHPh4q3a5L9N/KG1ilpwBM9FAYQ==}
     requiresBuild: true
     dependencies:
       '@pulumi/pulumi': 3.3.0
@@ -1847,10 +1845,10 @@ packages:
     dev: true
 
   /@pulumi/query/0.3.0:
-    resolution: {integrity: sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w==, tarball: '@pulumi/query/-/query-0.3.0.tgz'}
+    resolution: {integrity: sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w==}
 
   /@pulumi/random/4.0.0:
-    resolution: {integrity: sha512-ZjCmHVOLfzkzRvbpa9RtLfYobStq8LhWcjCvjSjOOJZAgBrMkl3CJYnFdrr/DEqrTwQ5HJnG8jU/StOkOQka3g==, tarball: '@pulumi/random/-/random-4.0.0.tgz'}
+    resolution: {integrity: sha512-ZjCmHVOLfzkzRvbpa9RtLfYobStq8LhWcjCvjSjOOJZAgBrMkl3CJYnFdrr/DEqrTwQ5HJnG8jU/StOkOQka3g==}
     requiresBuild: true
     dependencies:
       '@pulumi/pulumi': 3.0.0


### PR DESCRIPTION
We want to allow a custom policy response to be defined for a CF distribution.

To allow this, we had to bump the version @pulumi/aws to 4.1 (which bumped it to 4.3.8 for some reason).