### PR TITLE
Remove deprecated code

### DIFF
--- a/libs/buildstep/src/index.ts
+++ b/libs/buildstep/src/index.ts
@@ -49,10 +49,6 @@ export class BuildStep extends pulumi.ComponentResource {
         const runInDryRun = args.runInDryRun ?? true
 
         const buildStdOut = pulumi.output(args).apply(async (buildArgs) => {
-            if (pulumi.runtime.isTestModeEnabled()) {
-                return ''
-            }
-
             // Only run during preview step
             if (
                 (runInDryRun && pulumi.runtime.isDryRun()) ||


### PR DESCRIPTION
Looks like istestModeEnabled has been deprecated [here](https://github.com/pulumi/pulumi/pull/10400/files) and is causing issues with newer pulumi versions
![image](https://github.com/sevenwestmedia-labs/pulumi-components/assets/117131235/18c6142f-aabf-470a-9f15-869cc7308759)

Fix:

Remove the check to skip if testModeEnabled