### PR TITLE
allow overriding viewer-protocol-policy

### DIFF
--- a/.changeset/eleven-jobs-fry.md
+++ b/.changeset/eleven-jobs-fry.md
@@ -1,0 +1,5 @@
+---
+'@wanews/pulumi-static-site': patch
+---
+
+allow overriding the default viewer protocol policy

--- a/libs/pulumi-static-site/src/cloudfront.ts
+++ b/libs/pulumi-static-site/src/cloudfront.ts
@@ -27,6 +27,7 @@ export interface CfDistributionOptions {
         pulumi.Input<aws.types.input.cloudfront.DistributionOrderedCacheBehavior>[]
     >
     protect?: boolean
+    viewerProtocolPolicy?: pulumi.Input<string>
 }
 
 export interface DistributionArgs extends CfDistributionOptions {
@@ -102,7 +103,8 @@ export class Distribution extends pulumi.ComponentResource {
                           targetOriginId: originId.result,
                           allowedMethods: ['GET', 'HEAD', 'OPTIONS'],
                           cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
-                          viewerProtocolPolicy: 'redirect-to-https',
+                          viewerProtocolPolicy:
+                              args.viewerProtocolPolicy ?? 'redirect-to-https',
                           cachePolicyId:
                               args.cachePolicyId ??
                               managedCachingOptimizedCachePolicyId,


### PR DESCRIPTION
google search still doesn't follow chained redirects when moving a site, and therefore refuses when it encounters a redirect from http to https

this allows overriding the default `redirect-to-https` protocol policy