### PR TITLE
Add provider to RandomPassword

### DIFF
--- a/libs/pulumi-static-site/src/static-site.ts
+++ b/libs/pulumi-static-site/src/static-site.ts
@@ -104,6 +104,9 @@ export class StaticSite extends pulumi.ComponentResource {
                 number: true,
                 special: false,
             },
+            {
+                parent: this,
+            },
         )
 
         // Setup S3 Bucket


### PR DESCRIPTION
## What 
Addd a provider to Random String component

## Why
Seems to be erroring with deployments in auth  workflow with issues on provider invalid key
<img width="667" alt="image" src="https://github.com/user-attachments/assets/6cce2530-589e-47ca-b5d3-e46c97100d90">
