### PR TITLE
use pnpm 8 on workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Install pnpm
         run: |
-          npm i -g pnpm
+          npm i -g pnpm@8
           pnpm set verify-store-integrity false
 
       - name: pnpm install

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install pnpm
         run: |
-          npm i -g pnpm
+          npm i -g pnpm@8
           pnpm set verify-store-integrity false
 
       - name: pnpm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install pnpm
         run: |
-          npm i -g pnpm
+          npm i -g pnpm@8
           pnpm set verify-store-integrity false
 
       - name: pnpm install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install pnpm
         run: |
-          npm i -g pnpm
+          npm i -g pnpm@8
           pnpm set verify-store-integrity false
 
       - name: pnpm install


### PR DESCRIPTION
## What
Limit the pnpm version to 8 

##Why
- workflow failures
- Latest pnpm 9 is not compatible with node 16
- The code use aws-sdk v2 which is not compatible with node 18 