### PR TITLE
suppress the typescript errors to warn

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,11 +26,11 @@
             "extends": ["plugin:@nrwl/nx/typescript"],
             "rules": {
                 "@typescript-eslint/no-empty-function": "off",
-                "@typescript-eslint/no-empty-interface": "warn", // To be remvoed after upgrading to aws-sdk v3
-                "@typescript-eslint/ban-types": "warn", // To be remvoed after upgrading to ndode 18
-                "no-irregular-whitespace": "warn", // To be remvoed after upgrading to ndode 18
-                "@typescript-eslint/no-var-requires": "warn", // To be remvoed after upgrading to ndode 18
-                "no-var": "warn" // To be remvoed after upgrading to ndode 18
+                "@typescript-eslint/no-empty-interface": "warn", // To be removed after upgrading to aws-sdk v3
+                "@typescript-eslint/ban-types": "warn", // To be removed after upgrading to ndode 18
+                "no-irregular-whitespace": "warn", // To be removed after upgrading to ndode 18
+                "@typescript-eslint/no-var-requires": "warn", // To be removed after upgrading to ndode 18
+                "no-var": "warn" // To be removed after upgrading to ndode 18
             }
         },
         {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,7 +30,8 @@
                 "@typescript-eslint/ban-types": "warn", // To be removed after upgrading to node 18
                 "no-irregular-whitespace": "warn", // To be removed after upgrading to node 18
                 "@typescript-eslint/no-var-requires": "warn", // To be removed after upgrading to node 18
-                "no-var": "warn" // To be removed after upgrading to node 18
+                "no-var": "warn", // To be removed after upgrading to node 18
+                "@typescript-eslint/prefer-namespace-keyword": "warn"
             }
         },
         {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,10 +27,10 @@
             "rules": {
                 "@typescript-eslint/no-empty-function": "off",
                 "@typescript-eslint/no-empty-interface": "warn", // To be removed after upgrading to aws-sdk v3
-                "@typescript-eslint/ban-types": "warn", // To be removed after upgrading to ndode 18
-                "no-irregular-whitespace": "warn", // To be removed after upgrading to ndode 18
-                "@typescript-eslint/no-var-requires": "warn", // To be removed after upgrading to ndode 18
-                "no-var": "warn" // To be removed after upgrading to ndode 18
+                "@typescript-eslint/ban-types": "warn", // To be removed after upgrading to node 18
+                "no-irregular-whitespace": "warn", // To be removed after upgrading to node 18
+                "@typescript-eslint/no-var-requires": "warn", // To be removed after upgrading to node 18
+                "no-var": "warn" // To be removed after upgrading to node 18
             }
         },
         {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,12 @@
             "files": ["*.ts", "*.tsx"],
             "extends": ["plugin:@nrwl/nx/typescript"],
             "rules": {
-                "@typescript-eslint/no-empty-function": "off"
+                "@typescript-eslint/no-empty-function": "off",
+                "@typescript-eslint/no-empty-interface": "warn", // To be remvoed after upgrading to aws-sdk v3
+                "@typescript-eslint/ban-types": "warn", // To be remvoed after upgrading to ndode 18
+                "no-irregular-whitespace": "warn", // To be remvoed after upgrading to ndode 18
+                "@typescript-eslint/no-var-requires": "warn", // To be remvoed after upgrading to ndode 18
+                "no-var": "warn" // To be remvoed after upgrading to ndode 18
             }
         },
         {

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ name: PR Workflow
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
## What

Hide typescript errors as warnings

##WHY

- blocking CI
- code is still using very old libraries
- permanent fixes will need to be added when upgrading to node 18 in this ticket
  -  https://wanews.atlassian.net/browse/PLT-1368